### PR TITLE
A2 followup sweep — Config, container-inject, unlink guard, Ticket 017 + demo

### DIFF
--- a/docs/tickets/017-title-alignment-vs-columns-vs-page.md
+++ b/docs/tickets/017-title-alignment-vs-columns-vs-page.md
@@ -1,0 +1,42 @@
+# TICKET-017: Title element width — columns extent vs printable page width
+
+**Status:** Open — design decision required (breaking-vs-non-breaking trade-off)
+**Priority:** Low (cosmetic; visible in demo reports where columns don't span printable area)
+**Source:** design discussion 2026-08-23 — noticed while running the A2 Daily Sales demo
+**Scope:** `writer/src/Builder/ReportBuilder.php` (title band construction), possibly `writer/src/Layout/PageConfig.php`, possibly `writer/src/Renderer/StyleMap.php`
+
+## Problem
+
+`ReportBuilder::title($text, $height)` at `writer/src/Builder/ReportBuilder.php:87-91` constructs the title band as:
+
+```php
+$totalWidth = $this->totalWidth();
+$bands[] = new BandInstance('band_title', 'title', [
+    new ElementInstance('title', 0.0, 0.0, $totalWidth, $this->titleHeight, new TextContent($this->titleText)),
+]);
+```
+
+`totalWidth()` returns `max(column.x + column.width)` across all columns. The library's default StyleMap (`writer/src/Renderer/StyleMap.php:38-43`) applies `text-align: center` to `.fu-band-title`.
+
+Consequence: the title centers within the columns-extent box, not the printable-page-width area. On reports where columns are narrower than the printable area (e.g. three 120pt columns on a Letter page with 20pt margins → columns span 380pt, printable area is ~572pt), the title visually appears left-of-page-center by ~96pt.
+
+Visible today in `writer-app/src/Reports/DailySalesFiller.php`'s Daily Sales report (columns totalled 380pt, printable width ~572pt) before the workaround landing alongside this ticket.
+
+## Design options
+
+**Option A — Change default to page-width.** Modify `ReportBuilder::title()` to use `pageConfig.width - marginLeft - marginRight` instead of `totalWidth()`. Breaks every existing consumer's title positioning. Requires passing `PageConfig` into the builder somehow (currently the builder doesn't know about layout). Also note: `PageConfig` presently has no `marginRight` field — only `marginLeft`, `marginTop`, `marginBottom` — so this option would also require adding one (a small library-shape change on its own).
+
+**Option B — Opt-in flag.** Add `->titleAlignment('columns' | 'page')` or `->titleSpan('columns' | 'printable-area')` fluent method. Default preserves current behavior; opt-in gets page-centered title. No breaking change. Requires the builder to hold a PageConfig reference (or defer the width decision to layout time).
+
+**Option C — Move responsibility to the renderer.** Have the HtmlRenderer detect title bands and re-center them based on the page's printable-area width at render time. Bypasses the builder's need to know about PageConfig. Cleanest separation but leaks title-specific logic into the renderer.
+
+**Option D — Do nothing.** Consumers who want a page-centered title widen their last column so `totalWidth()` matches the printable-area width. Currently the accepted workaround (see the DailySalesFiller demo fix landing alongside this ticket).
+
+## Recommendation
+
+Not yet decided. Option B feels least invasive but adds API surface for a cosmetic-only feature. Option D is what the demo does today. Revisit when a real consumer complains, or when A3's five additional reports make the ordering-and-widening workarounds tedious.
+
+## Related
+
+- Discussion: 2026-08-23 session on A2 Daily Sales demo rendering
+- Demo workaround landed with this ticket: `writer-app/src/Reports/DailySalesFiller.php` columns widened so `totalWidth()` ≈ printable area (572pt on Letter with 20pt margins). Not a fix — just moves the visual anchor.

--- a/docs/tickets/README.md
+++ b/docs/tickets/README.md
@@ -23,6 +23,7 @@ Local ticket store — GitHub-issue-shaped so each file can be promoted to `edge
 | [013](013-brainstorm-structured-form-builder-subproject-b.md) | Brainstorm structured form builder (Sub-project B) | Epic | session-design | Blocked on Sub-project A |
 | [014](014-implement-v1-layout-engine.md) | Implement v1 layout engine per `docs/architecture/` specs | Epic | design | Backlog |
 | [015](015-implement-user-scripting.md) | Implement user-scripting per `docs/architecture/user-scripting.md` | Epic | design | Backlog |
+| [017](017-title-alignment-vs-columns-vs-page.md) | Title element width — columns extent vs printable page width | Low | design 2026-08-23 | Open |
 
 ## Fixed in the same session (no tickets — reference commits)
 

--- a/writer-app/bin/console
+++ b/writer-app/bin/console
@@ -18,6 +18,12 @@ switch ($command) {
         $config = Config::fromEnv();
         $path   = $config->sqlitePath() ?? (__DIR__ . '/../data/report-writer.sqlite');
 
+        if (!preg_match('/\.(sqlite3?|db)$/', $path)) {
+            fwrite(STDERR, "Refusing to seed non-sqlite path: {$path}\n");
+            fwrite(STDERR, "SQLITE_PATH must end in .sqlite, .sqlite3, or .db\n");
+            exit(2);
+        }
+
         if (file_exists($path)) {
             fwrite(STDERR, "Removing existing DB at {$path}\n");
             unlink($path);

--- a/writer-app/bin/console
+++ b/writer-app/bin/console
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use ReportWriter\App\Config;
 use ReportWriter\App\Database\Seed;
 use ReportWriter\App\Database\SqliteConnectionFactory;
 
@@ -14,7 +15,8 @@ $command = $argv[1] ?? 'help';
 
 switch ($command) {
     case 'db:seed':
-        $path = getenv('SQLITE_PATH') ?: (__DIR__ . '/../data/report-writer.sqlite');
+        $config = Config::fromEnv();
+        $path   = $config->sqlitePath() ?? (__DIR__ . '/../data/report-writer.sqlite');
 
         if (file_exists($path)) {
             fwrite(STDERR, "Removing existing DB at {$path}\n");

--- a/writer-app/public/index.php
+++ b/writer-app/public/index.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
-ReportWriter\App\Kernel::buildApp()->run();
+ReportWriter\App\Kernel::buildApp(null, ReportWriter\App\Config::fromEnv())->run();

--- a/writer-app/src/Config.php
+++ b/writer-app/src/Config.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App;
+
+/**
+ * Immutable configuration read once at the composition root.
+ *
+ * Two paths in: {@see Config::fromEnv()} for production/CLI entry points,
+ * or direct construction for tests. Consumers pull values through
+ * {@see sqlitePath()} / {@see appDebug()} rather than calling getenv() themselves.
+ */
+final class Config
+{
+    private ?string $sqlitePath;
+    private bool $appDebug;
+
+    public function __construct(?string $sqlitePath, bool $appDebug)
+    {
+        $this->sqlitePath = $sqlitePath;
+        $this->appDebug   = $appDebug;
+    }
+
+    public static function fromEnv(): self
+    {
+        $sqlite = getenv('SQLITE_PATH');
+        $debug  = getenv('APP_DEBUG');
+
+        return new self(
+            $sqlite !== false && $sqlite !== '' ? $sqlite : null,
+            $debug !== false && $debug !== '' && $debug !== '0'
+        );
+    }
+
+    public function sqlitePath(): ?string
+    {
+        return $this->sqlitePath;
+    }
+
+    public function appDebug(): bool
+    {
+        return $this->appDebug;
+    }
+}

--- a/writer-app/src/Http/ReportController.php
+++ b/writer-app/src/Http/ReportController.php
@@ -9,20 +9,26 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use ReportWriter\App\Reports\ReportRegistry;
 use ReportWriter\Interfaces\ReportFillerInterface;
-use ReportWriter\Layout\Flattener;
 use ReportWriter\Layout\LayoutService;
-use ReportWriter\Layout\PageConfig;
 use ReportWriter\Renderer\HtmlRenderer;
 
 final class ReportController
 {
     private ContainerInterface $container;
     private ReportRegistry $registry;
+    private LayoutService $layoutService;
+    private HtmlRenderer $renderer;
 
-    public function __construct(ContainerInterface $container, ReportRegistry $registry)
-    {
-        $this->container = $container;
-        $this->registry  = $registry;
+    public function __construct(
+        ContainerInterface $container,
+        ReportRegistry $registry,
+        LayoutService $layoutService,
+        HtmlRenderer $renderer
+    ) {
+        $this->container     = $container;
+        $this->registry      = $registry;
+        $this->layoutService = $layoutService;
+        $this->renderer      = $renderer;
     }
 
     /**
@@ -37,9 +43,8 @@ final class ReportController
         $params   = $request->getQueryParams();
         $instance = $filler->fill($params);
 
-        $pageConfig = new PageConfig();
-        $stream     = (new LayoutService(new Flattener(), $pageConfig))->layout($instance);
-        $html       = (new HtmlRenderer($pageConfig))->render($stream);
+        $stream = $this->layoutService->layout($instance);
+        $html   = $this->renderer->render($stream);
 
         $response->getBody()->write($html);
 

--- a/writer-app/src/Kernel.php
+++ b/writer-app/src/Kernel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ReportWriter\App;
 
 use PDO;
+use ReportWriter\App\Config;
 use ReportWriter\App\Database\SqliteConnectionFactory;
 use ReportWriter\App\Http\HealthController;
 use ReportWriter\App\Http\JsonErrorHandler;
@@ -21,9 +22,10 @@ use Slim\Psr7\Factory\ResponseFactory;
 
 final class Kernel
 {
-    public static function buildApp(?Container $container = null): App
+    public static function buildApp(?Container $container = null, ?Config $config = null): App
     {
-        $container = $container ?? self::defaultContainer();
+        $config    = $config ?? Config::fromEnv();
+        $container = $container ?? self::defaultContainer($config);
 
         $app = SlimAppFactory::create();
 
@@ -35,22 +37,21 @@ final class Kernel
             return $container->get(ReportController::class)->show($request, $response, $args);
         });
 
-        $debug = (bool) (getenv('APP_DEBUG') ?: false);
-        $errorMiddleware = $app->addErrorMiddleware($debug, true, true);
-        $errorMiddleware->setDefaultErrorHandler(new JsonErrorHandler(new ResponseFactory(), $debug));
+        $errorMiddleware = $app->addErrorMiddleware($config->appDebug(), true, true);
+        $errorMiddleware->setDefaultErrorHandler(new JsonErrorHandler(new ResponseFactory(), $config->appDebug()));
 
         return $app;
     }
 
-    public static function defaultContainer(): Container
+    public static function defaultContainer(Config $config): Container
     {
         $c = new Container();
 
         $c->set(HealthController::class, static fn () => new HealthController());
 
-        $c->set(PDO::class, static function (): PDO {
-            $path = getenv('SQLITE_PATH') ?: null;
-            if ($path === null || $path === '') {
+        $c->set(PDO::class, static function () use ($config): PDO {
+            $path = $config->sqlitePath();
+            if ($path === null) {
                 throw new RuntimeException('SQLITE_PATH env var must be set for production use.');
             }
             return SqliteConnectionFactory::createFromPath($path);

--- a/writer-app/src/Kernel.php
+++ b/writer-app/src/Kernel.php
@@ -15,6 +15,10 @@ use ReportWriter\App\Reports\DataSource\SqliteDailySalesProvider;
 use ReportWriter\App\Reports\ParamSpec;
 use ReportWriter\App\Reports\ReportDefinition;
 use ReportWriter\App\Reports\ReportRegistry;
+use ReportWriter\Layout\Flattener;
+use ReportWriter\Layout\LayoutService;
+use ReportWriter\Layout\PageConfig;
+use ReportWriter\Renderer\HtmlRenderer;
 use RuntimeException;
 use Slim\App;
 use Slim\Factory\AppFactory as SlimAppFactory;
@@ -72,8 +76,20 @@ final class Kernel
             ),
         ]));
 
+        $c->set(PageConfig::class,   static fn () => new PageConfig());
+        $c->set(Flattener::class,    static fn () => new Flattener());
+        $c->set(LayoutService::class,
+            static fn (Container $c) => new LayoutService($c->get(Flattener::class), $c->get(PageConfig::class)));
+        $c->set(HtmlRenderer::class,
+            static fn (Container $c) => new HtmlRenderer($c->get(PageConfig::class)));
+
         $c->set(ReportController::class,
-            static fn (Container $c) => new ReportController($c, $c->get(ReportRegistry::class)));
+            static fn (Container $c) => new ReportController(
+                $c,
+                $c->get(ReportRegistry::class),
+                $c->get(LayoutService::class),
+                $c->get(HtmlRenderer::class)
+            ));
 
         return $c;
     }

--- a/writer-app/src/Reports/DailySalesFiller.php
+++ b/writer-app/src/Reports/DailySalesFiller.php
@@ -29,9 +29,9 @@ final class DailySalesFiller implements ReportFillerInterface
         return ReportBuilder::create('daily-sales')
             ->title("Daily Sales — {$date}")
             ->columns([
-                Column::make('order_id',    'Order',       0,   120),
-                Column::make('closed_at',   'Closed',      130, 120),
-                Column::make('total_cents', 'Total',       260, 120)
+                Column::make('order_id',    'Order',       0,   180),
+                Column::make('closed_at',   'Closed',      190, 180),
+                Column::make('total_cents', 'Total',       380, 192)
                     ->sum()
                     ->alignRight()
                     ->format($currency),

--- a/writer-app/tests/Support/AppFactory.php
+++ b/writer-app/tests/Support/AppFactory.php
@@ -4,22 +4,20 @@ declare(strict_types=1);
 
 namespace ReportWriter\App\Tests\Support;
 
+use ReportWriter\App\Config;
 use ReportWriter\App\Container;
 use ReportWriter\App\Kernel;
 use Slim\App;
 
 final class AppFactory
 {
-    /**
-     * @param callable(Container): void|null $overrides
-     *   Optional mutator that runs against the default container before app boot.
-     */
-    public static function buildTestApp(?callable $overrides = null): App
+    public static function buildTestApp(?callable $overrides = null, ?Config $config = null): App
     {
-        $container = Kernel::defaultContainer();
+        $config    = $config ?? new Config(null, false);
+        $container = Kernel::defaultContainer($config);
         if ($overrides !== null) {
             $overrides($container);
         }
-        return Kernel::buildApp($container);
+        return Kernel::buildApp($container, $config);
     }
 }

--- a/writer-app/tests/Unit/ConfigTest.php
+++ b/writer-app/tests/Unit/ConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Config;
+
+final class ConfigTest extends TestCase
+{
+    public function testAccessorsReturnConstructedValues(): void
+    {
+        $c = new Config('/tmp/x.sqlite', true);
+        $this->assertSame('/tmp/x.sqlite', $c->sqlitePath());
+        $this->assertTrue($c->appDebug());
+    }
+
+    public function testNullSqlitePathIsPreserved(): void
+    {
+        $c = new Config(null, false);
+        $this->assertNull($c->sqlitePath());
+    }
+
+    /**
+     * @dataProvider debugTruthiness
+     */
+    public function testFromEnvReadsDebugTruthily(?string $envValue, bool $expected): void
+    {
+        if ($envValue === null) {
+            putenv('APP_DEBUG');
+        } else {
+            putenv('APP_DEBUG=' . $envValue);
+        }
+        putenv('SQLITE_PATH');
+
+        try {
+            $this->assertSame($expected, Config::fromEnv()->appDebug());
+        } finally {
+            putenv('APP_DEBUG');
+        }
+    }
+
+    public static function debugTruthiness(): array
+    {
+        return [
+            'unset'    => [null, false],
+            'empty'    => ['', false],
+            'zero'     => ['0', false],
+            'one'      => ['1', true],
+            'true'     => ['true', true],  // any non-empty non-zero string
+        ];
+    }
+
+    public function testFromEnvReadsSqlitePathOrNull(): void
+    {
+        putenv('APP_DEBUG');
+        putenv('SQLITE_PATH=/tmp/from-env.sqlite');
+        try {
+            $this->assertSame('/tmp/from-env.sqlite', Config::fromEnv()->sqlitePath());
+        } finally {
+            putenv('SQLITE_PATH');
+        }
+
+        putenv('SQLITE_PATH');
+        $this->assertNull(Config::fromEnv()->sqlitePath());
+    }
+}


### PR DESCRIPTION
## Summary

Four small changes the multi-agent reviewers flagged during A2 for \"before A3 lands\" attention:

- **Config value object** (`b0d4de8`) — extracted `ReportWriter\App\Config` to centralize env reads. `Kernel::buildApp(?Container, ?Config)` and `Kernel::defaultContainer(Config)` take Config explicitly; `bin/console`, `public/index.php`, `AppFactory` follow. Zero `getenv(...)` calls remain outside `Config::fromEnv()`. Addresses Task 7 + Task 8 DRY/SOLID reviewer flags on composition-root purity.

- **Container-inject `LayoutService` / `HtmlRenderer` / `PageConfig` / `Flattener`** (`9a8cdd9`) — registered as single-instance bindings in `Kernel::defaultContainer`; `ReportController` accepts them via constructor instead of `new`ing inline per request. Retires Task 7's DIP flag.

- **`bin/console db:seed` unlink guard** (`1cdd712`) — `SQLITE_PATH` must end in `.sqlite` / `.sqlite3` / `.db` before the destructive `unlink` fires. Otherwise refuses with a STDERR diagnostic and exit 2. Retires security-scanner's Medium finding on the destructive default.

- **Title-alignment: file Ticket 017 + widen Daily Sales demo columns** (`2ccdab4`) — filed [Ticket 017](docs/tickets/017-title-alignment-vs-columns-vs-page.md) documenting that `ReportBuilder::title()` centers text within columns-extent, not printable-page-width. Widened Daily Sales columns so `totalWidth()` = 572pt (Option D workaround). Ticket 018 (on `feat/018-pageconfig-right-margin`) unblocks the proper library-side fix.

## Test evidence

- `writer-app` suite: **30 tests / 61 assertions green** (22 A2 baseline + 8 new `ConfigTest` cases). No regressions.
- Library suite: **117 tests green** — untouched by this branch.
- Every task ran through spec-compliance review + `.claude/agents/dry-solid-reviewer` before landing on the branch.

## Test plan for reviewer

- [ ] \`cd writer-app && composer install && vendor/bin/phpunit\` — 30 green
- [ ] \`./scripts/demo-up\` — brings up Docker, seeds, prints URLs
- [ ] Browser: http://localhost:8090/api/reports/daily-sales?date=2026-08-22 — title visually centers on page (was left-of-center before this branch)
- [ ] \`docker exec report-writer-php php /app/writer-app/bin/console db:seed\` — succeeds against the default SQLite path
- [ ] \`SQLITE_PATH=/tmp/test.txt docker exec report-writer-php php /app/writer-app/bin/console db:seed\` — refuses with exit 2, no file created

## Related

- [Ticket 016](docs/tickets/016-extension-hooks-lifecycle-plus-immutability-retrofit.md) (extension hooks) — sibling design work, on main directly.
- [Ticket 017](docs/tickets/017-title-alignment-vs-columns-vs-page.md) filed in this branch — proper library fix requires Ticket 018.
- [Ticket 018](docs/tickets/018-pageconfig-right-margin-and-printable-width.md) — on \`feat/018-pageconfig-right-margin\` in a separate PR; unblocks Ticket 017 Options A + C.

## Follow-up items surfaced during review (not in this PR)

- Extract \`FillerRegistry\` when a second controller needs filler resolution by service-id — retires the last Service Locator use of \`ContainerInterface\` in \`ReportController\`.
- Extract \`KeyedRegistry\` base when a fourth throw-on-miss registry lands (currently 3: FormatterRegistry, DataSourceRegistry, ReportRegistry).
- Slim \`InvocationStrategy\` extraction when a third route lands (A3 territory).