### PR TITLE
Ticket 018: PageConfig gains marginRight + printableWidth() (+ printableHeight rename)

### DIFF
--- a/docs/tickets/018-pageconfig-right-margin-and-printable-width.md
+++ b/docs/tickets/018-pageconfig-right-margin-and-printable-width.md
@@ -1,0 +1,85 @@
+# TICKET-018: PageConfig missing right margin and printableWidth()
+
+**Status:** ✅ Closed (2026-08-23) — implementation shipped in the same commit
+**Priority:** Medium (unblocks [Ticket 017](017-title-alignment-vs-columns-vs-page.md) Options A + C, and closes an API asymmetry in PageConfig)
+**Source:** design discussion 2026-08-23 — surfaced while exploring Ticket 017 title-alignment options
+**Scope:** `writer/src/Layout/PageConfig.php`, `writer/src/Layout/LayoutService.php` (one-line caller update from the rename below), `writer/tests/Unit/Layout/PageConfigTest.php` (new)
+
+## Problem
+
+`PageConfig` currently defines three margin constants — `DEFAULT_MARGIN_TOP`, `DEFAULT_MARGIN_BOTTOM`, `DEFAULT_MARGIN_LEFT` — plus corresponding fields, constructor params, and getters. **No `DEFAULT_MARGIN_RIGHT` exists**, and there is no field, constructor param, getter, or `printableWidth()` method for the horizontal analog of the existing `printableHeight()`.
+
+Consequence: the vertical axis is honest (`printableHeight() = height - marginTop - marginBottom` at `writer/src/Layout/PageConfig.php:43`, used by `LayoutService` to detect page overflow) but the horizontal axis is asymmetric. Any code that wants "printable page width" today has to compute `pageConfig.getWidth() - pageConfig.getMarginLeft()`, which:
+
+- Assumes zero right margin — silently different from the visual convention (all four sides usually have margins)
+- Blocks [Ticket 017](017-title-alignment-vs-columns-vs-page.md) Option A (title centers on page width) and Option C (renderer re-centers on printable area) — neither can be implemented without a computable printable-width value from PageConfig
+
+`LayoutService` today does NOT enforce a right-side bound — elements can overflow past `width - marginLeft` and layout silently allows it. Whether to add right-side overflow detection is a separate design question and NOT in scope for this ticket.
+
+## Proposed fix
+
+Additive changes to `writer/src/Layout/PageConfig.php`, plus one small rename (see item 6 below) that touches `LayoutService`. Non-breaking for external consumers of the 0.1.0 library because (a) constructor additions have default values, and (b) the renamed method has no external consumers — only one internal caller in `LayoutService`, updated in the same commit.
+
+1. Add constant:
+   ```php
+   public const DEFAULT_MARGIN_RIGHT = 20.0;
+   ```
+
+2. Add field:
+   ```php
+   private float $marginRight;
+   ```
+
+3. Add constructor parameter (last positional, default value → non-breaking for existing `new PageConfig(...)` calls):
+   ```php
+   public function __construct(
+       float $width        = self::DEFAULT_WIDTH,
+       float $height       = self::DEFAULT_HEIGHT,
+       float $marginTop    = self::DEFAULT_MARGIN_TOP,
+       float $marginBottom = self::DEFAULT_MARGIN_BOTTOM,
+       float $marginLeft   = self::DEFAULT_MARGIN_LEFT,
+       float $marginRight  = self::DEFAULT_MARGIN_RIGHT
+   ) {
+       // ...existing assignments...
+       $this->marginRight = $marginRight;
+   }
+   ```
+
+4. Add getter:
+   ```php
+   public function getMarginRight(): float { return $this->marginRight; }
+   ```
+
+5. Add method (analog of the renamed `printableHeight()` from item 6):
+   ```php
+   public function printableWidth(): float
+   {
+       return $this->width - $this->marginLeft - $this->marginRight;
+   }
+   ```
+
+6. Rename existing method `usableHeight()` → `printableHeight()` for naming consistency with the new `printableWidth()`. The word "printable" is more precise for a reporting library targeting print output; keeping two names for one concept ("usable" and "printable") would be a permanent smell. Only one caller: `writer/src/Layout/LayoutService.php:33`, updated in the same commit. No external consumers of the old name (library is 0.1.0 with no downstream Packagist users).
+
+## Acceptance criteria
+
+- [x] `PageConfig` has `DEFAULT_MARGIN_RIGHT`, `marginRight` field, constructor param (default = 20.0), `getMarginRight()`, `printableWidth()`
+- [x] Method `usableHeight()` renamed to `printableHeight()`; the one internal caller in `LayoutService` updated in the same commit
+- [x] All existing library tests pass unchanged in behavior (constructor param default preserves backward compat; rename is transparent because no test asserted on the old method name)
+- [x] New unit tests for `PageConfig` covering: default marginRight, custom marginRight override, `printableWidth()` returns `width - marginLeft - marginRight` for both default and custom values, `printableHeight()` still behaves the same after rename
+- [x] `HtmlRenderer` unchanged — this ticket is PageConfig + one-line LayoutService caller update only. Consumer adoption of `printableWidth()` comes with Ticket 017 fix work.
+
+## Non-goals
+
+- Fixing Ticket 017 (title alignment) — this ticket unblocks it, doesn't fix it
+- Adding right-side overflow detection to LayoutService — separate design question
+- Modifying any consumer (`writer-app/`, `frontend/`) to use `printableWidth()` — deferred until a consumer needs it
+
+## Related
+
+- Unblocks [Ticket 017](017-title-alignment-vs-columns-vs-page.md) Options A + C
+- Surfaced in the [Ticket 017](017-title-alignment-vs-columns-vs-page.md) filing during 2026-08-23 backlog sweep
+
+## Implementation notes (2026-08-23)
+
+- The original library method was `usableHeight()`. After a first-pass implementation added `printableHeight()` as an alias (introducing a two-names-for-one-concept smell), we opted instead to rename `usableHeight()` → `printableHeight()` and update the single internal caller in `LayoutService`. Naming symmetry with the new `printableWidth()` restored; no permanent alias smell; library still at 0.1.0 with no external consumers means the rename is a safe move.
+- Full library suite: 117 → 122 tests. Zero behavior change for existing consumers.

--- a/docs/tickets/README.md
+++ b/docs/tickets/README.md
@@ -24,6 +24,7 @@ Local ticket store — GitHub-issue-shaped so each file can be promoted to `edge
 | [014](014-implement-v1-layout-engine.md) | Implement v1 layout engine per `docs/architecture/` specs | Epic | design | Backlog |
 | [015](015-implement-user-scripting.md) | Implement user-scripting per `docs/architecture/user-scripting.md` | Epic | design | ❌ Superseded 2026-08-23 by extension-hooks.md + Ticket 016 |
 | [016](016-extension-hooks-lifecycle-plus-immutability-retrofit.md) | Add lifecycle hooks to ReportBuilder + DefinitionFiller (immutable-fluent); retrofit `onBand` immutability | Medium | design session 2026-08-23 | Open |
+| [018](018-pageconfig-right-margin-and-printable-width.md) | PageConfig missing right margin and printableWidth() | Medium | design 2026-08-23 | ✅ Closed (2026-08-23) |
 
 ## Fixed in the same session (no tickets — reference commits)
 

--- a/writer/src/Layout/LayoutService.php
+++ b/writer/src/Layout/LayoutService.php
@@ -30,7 +30,7 @@ class LayoutService
         $pages       = [];
         $currentPage = new Page(1);
         $cursor      = $this->pageConfig->getMarginTop();
-        $usable      = $this->pageConfig->usableHeight();
+        $usable      = $this->pageConfig->printableHeight();
         $bottom      = $this->pageConfig->getMarginTop() + $usable;
 
         foreach ($bands as $band) {

--- a/writer/src/Layout/PageConfig.php
+++ b/writer/src/Layout/PageConfig.php
@@ -11,25 +11,29 @@ class PageConfig
     public const DEFAULT_MARGIN_TOP    = 20.0;
     public const DEFAULT_MARGIN_BOTTOM = 20.0;
     public const DEFAULT_MARGIN_LEFT   = 20.0;
+    public const DEFAULT_MARGIN_RIGHT  = 20.0;
 
     private float $width;
     private float $height;
     private float $marginTop;
     private float $marginBottom;
     private float $marginLeft;
+    private float $marginRight;
 
     public function __construct(
         float $width        = self::DEFAULT_WIDTH,
         float $height       = self::DEFAULT_HEIGHT,
         float $marginTop    = self::DEFAULT_MARGIN_TOP,
         float $marginBottom = self::DEFAULT_MARGIN_BOTTOM,
-        float $marginLeft   = self::DEFAULT_MARGIN_LEFT
+        float $marginLeft   = self::DEFAULT_MARGIN_LEFT,
+        float $marginRight  = self::DEFAULT_MARGIN_RIGHT
     ) {
         $this->width        = $width;
         $this->height       = $height;
         $this->marginTop    = $marginTop;
         $this->marginBottom = $marginBottom;
         $this->marginLeft   = $marginLeft;
+        $this->marginRight  = $marginRight;
     }
 
     public function getWidth(): float { return $this->width; }
@@ -37,9 +41,15 @@ class PageConfig
     public function getMarginTop(): float { return $this->marginTop; }
     public function getMarginBottom(): float { return $this->marginBottom; }
     public function getMarginLeft(): float { return $this->marginLeft; }
+    public function getMarginRight(): float { return $this->marginRight; }
 
-    public function usableHeight(): float
+    public function printableHeight(): float
     {
         return $this->height - $this->marginTop - $this->marginBottom;
+    }
+
+    public function printableWidth(): float
+    {
+        return $this->width - $this->marginLeft - $this->marginRight;
     }
 }

--- a/writer/tests/Unit/Layout/PageConfigTest.php
+++ b/writer/tests/Unit/Layout/PageConfigTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\Tests\Unit\Layout;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\Layout\PageConfig;
+
+final class PageConfigTest extends TestCase
+{
+    public function testDefaultsMatchUsLetter(): void
+    {
+        $c = new PageConfig();
+
+        $this->assertSame(612.0, $c->getWidth());
+        $this->assertSame(792.0, $c->getHeight());
+        $this->assertSame(20.0, $c->getMarginTop());
+        $this->assertSame(20.0, $c->getMarginBottom());
+        $this->assertSame(20.0, $c->getMarginLeft());
+        $this->assertSame(20.0, $c->getMarginRight());
+    }
+
+    public function testCustomMarginRightIsPreserved(): void
+    {
+        $c = new PageConfig(
+            PageConfig::DEFAULT_WIDTH,
+            PageConfig::DEFAULT_HEIGHT,
+            PageConfig::DEFAULT_MARGIN_TOP,
+            PageConfig::DEFAULT_MARGIN_BOTTOM,
+            PageConfig::DEFAULT_MARGIN_LEFT,
+            36.0
+        );
+
+        $this->assertSame(36.0, $c->getMarginRight());
+    }
+
+    public function testPrintableHeightSubtractsTopAndBottomMargins(): void
+    {
+        $c = new PageConfig(612.0, 792.0, 20.0, 20.0);
+        $this->assertSame(752.0, $c->printableHeight());
+    }
+
+    public function testPrintableWidthSubtractsLeftAndRightMargins(): void
+    {
+        $c = new PageConfig();
+        $this->assertSame(572.0, $c->printableWidth());
+    }
+
+    public function testPrintableWidthWithCustomMargins(): void
+    {
+        $c = new PageConfig(612.0, 792.0, 20.0, 20.0, 40.0, 30.0);
+        $this->assertSame(542.0, $c->printableWidth());
+    }
+}


### PR DESCRIPTION
## Summary

Fills the horizontal-axis API asymmetry in \`PageConfig\`. Prior state: 3 margins (top, bottom, left) + \`usableHeight()\`. No right margin, no \`printableWidth()\`. Vertical axis honest; horizontal not.

**Changes:**

- Additive, non-breaking constructor: \`DEFAULT_MARGIN_RIGHT = 20.0\`, \`marginRight\` field, last-positional constructor param (default value), \`getMarginRight()\`, \`printableWidth()\`.
- Rename \`usableHeight()\` → \`printableHeight()\` for naming symmetry with the new \`printableWidth()\`. One internal caller (\`LayoutService:33\`) updated in the same commit. Library is 0.1.0 with no external Packagist consumers — the rename is safe. Chosen over an alias approach (which would have introduced a permanent two-names-for-one-concept smell).

**No consumer adopts \`printableWidth()\` in this PR.** Consumer changes ride with the [Ticket 017](docs/tickets/017-title-alignment-vs-columns-vs-page.md) fix when its design option is chosen.

## Why

[Ticket 018](docs/tickets/018-pageconfig-right-margin-and-printable-width.md) documents this: any code wanting \"printable page width\" today has to compute \`getWidth() - getMarginLeft()\` and silently assume zero right margin. Blocks Ticket 017 Options A and C (title-alignment fixes that need a computable printable-width value).

## Test evidence

- Library suite: **117 → 122 tests green** (+5 in new \`PageConfigTest\`). Zero behavior change for existing consumers.
- Passed spec-compliance review + \`.claude/agents/dry-solid-reviewer\` review.

## Test plan for reviewer

- [ ] \`cd writer && composer install && vendor/bin/phpunit\` — 122 green
- [ ] Spot-check: \`grep -rn 'usableHeight' writer\` — expected: zero matches (rename complete)
- [ ] Spot-check: \`(new ReportWriter\\Layout\\PageConfig())->printableWidth()\` — returns 572.0

## Related

- Ticket [018](docs/tickets/018-pageconfig-right-margin-and-printable-width.md) — self-closing (implementation shipped in the same commit)
- Unblocks [Ticket 017](docs/tickets/017-title-alignment-vs-columns-vs-page.md) Options A + C — Ticket 017 lives on \`chore/a2-followup-sweep\` in a separate PR
- Both PRs merge independently; no ordering constraint