### PR TITLE
Ticket 016: Extension hooks API + DefinitionFiller immutability retrofit

### DIFF
--- a/writer/src/Builder/ReportBuilder.php
+++ b/writer/src/Builder/ReportBuilder.php
@@ -6,6 +6,7 @@ namespace ReportWriter\Builder;
 
 use ReportWriter\Expression\EvalContext;
 use ReportWriter\Expression\StaticExpression;
+use ReportWriter\Fill\BandContext;
 use ReportWriter\Instance\BandInstance;
 use ReportWriter\Instance\Content\TextContent;
 use ReportWriter\Instance\ElementInstance;
@@ -31,6 +32,13 @@ class ReportBuilder
 
     /** @var string[] */
     private array $groupKeys = [];
+
+    /** @var callable[] */
+    private array $beforeBuildCallbacks = [];
+    /** @var callable[] */
+    private array $afterBuildCallbacks = [];
+    /** @var array<string, callable[]> keyed by band-type ('title', 'col-header', 'detail', 'group-header', 'group-footer', 'summary') */
+    private array $bandCallbacks = [];
 
     private function __construct(string $reportId)
     {
@@ -80,39 +88,136 @@ class ReportBuilder
         return $clone;
     }
 
+    /**
+     * Register a callback that fires before `build()` constructs bands, receiving
+     * the rows array and returning a (possibly transformed) rows array.
+     *
+     * Immutable-fluent: returns a clone. Callers MUST reassign
+     * (`$b = $b->beforeBuild(...)`); fire-and-forget silently drops the callback.
+     *
+     * Non-nullable return type: to no-op, return the input unchanged.
+     *
+     * @param callable(array): array $callback
+     */
+    public function beforeBuild(callable $callback): self
+    {
+        $clone = clone $this;
+        $clone->beforeBuildCallbacks[] = $callback;
+        return $clone;
+    }
+
+    /**
+     * Register a callback that fires just before `build()` returns. Receives the
+     * ReportInstance and returns a (possibly transformed) ReportInstance.
+     *
+     * Immutable-fluent: returns a clone. Callers MUST reassign.
+     *
+     * Non-nullable return type: to no-op, return the input unchanged.
+     *
+     * @param callable(ReportInstance): ReportInstance $callback
+     */
+    public function afterBuild(callable $callback): self
+    {
+        $clone = clone $this;
+        $clone->afterBuildCallbacks[] = $callback;
+        return $clone;
+    }
+
+    /**
+     * Register a callback for a band-type. The callback fires after each band of
+     * the given type is built, before it is added to the report. Return null to
+     * suppress the band, or return a (modified) BandInstance to use instead.
+     *
+     * The `$bandType` key matches the band-TYPE string ('title', 'col-header',
+     * 'detail', 'group-header', 'group-footer', 'summary') — not a per-instance
+     * ID. Register once against 'detail' to fire for every detail band.
+     *
+     * Callbacks chain: each receives the output of the previous. If any returns
+     * null the band is suppressed and remaining callbacks are skipped.
+     *
+     * Immutable-fluent: returns a clone. Callers MUST reassign.
+     *
+     * @param callable(BandInstance, BandContext): ?BandInstance $callback
+     */
+    public function onBand(string $bandType, callable $callback): self
+    {
+        $clone = clone $this;
+        $clone->bandCallbacks[$bandType][] = $callback;
+        return $clone;
+    }
+
     public function build(): ReportInstance
     {
+        $rows = array_reduce(
+            $this->beforeBuildCallbacks,
+            fn ($acc, $cb) => $cb($acc),
+            $this->rows
+        );
+
         $bands = [];
 
         if ($this->titleText !== null) {
             $totalWidth = $this->totalWidth();
-            $bands[] = new BandInstance('band_title', 'title', [
+            $titleBand  = new BandInstance('band_title', 'title', [
                 new ElementInstance('title', 0.0, 0.0, $totalWidth, $this->titleHeight, new TextContent($this->titleText)),
             ]);
+            $titleBand = $this->applyBandCallbacks('title', $titleBand, new BandContext([], null, [], []));
+            if ($titleBand !== null) {
+                $bands[] = $titleBand;
+            }
         }
 
-        $bands[] = new BandInstance('band_col_hdr', 'col-header', $this->headerElements());
+        $colHdrBand = new BandInstance('band_col_hdr', 'col-header', $this->headerElements());
+        $colHdrBand = $this->applyBandCallbacks('col-header', $colHdrBand, new BandContext([], null, [], []));
+        if ($colHdrBand !== null) {
+            $bands[] = $colHdrBand;
+        }
 
         if (!empty($this->groupKeys)) {
-            $result = $this->buildGroupBands($this->rows, $this->groupKeys, 'g');
+            $result = $this->buildGroupBands($rows, $this->groupKeys, 'g');
             foreach ($result['bands'] as $b) {
                 $bands[] = $b;
             }
             $grandRows = $result['rows'];
         } else {
             $grandRows = [];
-            foreach ($this->rows as $rowIdx => $row) {
-                $bands[]     = new BandInstance("band_detail_r{$rowIdx}", 'detail', $this->detailElements("r{$rowIdx}", $row));
+            foreach ($rows as $rowIdx => $row) {
+                $detailBand = new BandInstance("band_detail_r{$rowIdx}", 'detail', $this->detailElements("r{$rowIdx}", $row));
+                $detailBand = $this->applyBandCallbacks('detail', $detailBand, new BandContext($row, null, [], []));
+                if ($detailBand !== null) {
+                    $bands[] = $detailBand;
+                }
                 $grandRows[] = $row;
             }
         }
 
-        $bands[] = new BandInstance(
+        $summaryBand = new BandInstance(
             'band_summary', 'summary',
             $this->summaryElements($grandRows)
         );
+        $summaryBand = $this->applyBandCallbacks('summary', $summaryBand, new BandContext([], null, $grandRows, []));
+        if ($summaryBand !== null) {
+            $bands[] = $summaryBand;
+        }
 
-        return new ReportInstance($this->reportId, $bands);
+        $instance = new ReportInstance($this->reportId, $bands);
+
+        return array_reduce(
+            $this->afterBuildCallbacks,
+            fn ($acc, $cb) => $cb($acc),
+            $instance
+        );
+    }
+
+    private function applyBandCallbacks(string $bandType, BandInstance $band, BandContext $ctx): ?BandInstance
+    {
+        foreach ($this->bandCallbacks[$bandType] ?? [] as $callback) {
+            $band = $callback($band, $ctx);
+            if ($band === null) {
+                return null;
+            }
+        }
+        return $band;
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -228,16 +333,28 @@ class ReportBuilder
         foreach (Grouping::byField($rows, $key) as $groupValue => $groupRows) {
             $safeId  = $prefix . $groupIdx++;
 
-            $bands[] = new BandInstance("band_grp_hdr_{$safeId}", 'group-header', [
+            $groupHdrBand = new BandInstance("band_grp_hdr_{$safeId}", 'group-header', [
                 new ElementInstance(
                     "grp_hdr_{$safeId}", 0.0, 0.0, $totalWidth, $this->groupHdrHeight,
                     new TextContent((string) $groupValue)
                 ),
             ]);
+            $groupHdrBand = $this->applyBandCallbacks(
+                'group-header',
+                $groupHdrBand,
+                new BandContext([], (string) $groupValue, $groupRows, [])
+            );
+            if ($groupHdrBand !== null) {
+                $bands[] = $groupHdrBand;
+            }
 
             if ($isLeaf) {
                 foreach ($groupRows as $rowIdx => $row) {
-                    $bands[]   = new BandInstance("band_detail_{$safeId}_r{$rowIdx}", 'detail', $this->detailElements("{$safeId}_r{$rowIdx}", $row));
+                    $detailBand = new BandInstance("band_detail_{$safeId}_r{$rowIdx}", 'detail', $this->detailElements("{$safeId}_r{$rowIdx}", $row));
+                    $detailBand = $this->applyBandCallbacks('detail', $detailBand, new BandContext($row, null, [], []));
+                    if ($detailBand !== null) {
+                        $bands[] = $detailBand;
+                    }
                     $allRows[] = $row;
                 }
                 $footerRows = $groupRows;
@@ -252,10 +369,18 @@ class ReportBuilder
                 $footerRows = $result['rows'];
             }
 
-            $bands[] = new BandInstance(
+            $groupFtrBand = new BandInstance(
                 "band_grp_ftr_{$safeId}", 'group-footer',
                 $this->footerElements("grp_ftr_{$safeId}", $footerRows, $this->groupFtrHeight)
             );
+            $groupFtrBand = $this->applyBandCallbacks(
+                'group-footer',
+                $groupFtrBand,
+                new BandContext([], (string) $groupValue, $footerRows, [])
+            );
+            if ($groupFtrBand !== null) {
+                $bands[] = $groupFtrBand;
+            }
         }
 
         return ['bands' => $bands, 'rows' => $allRows];

--- a/writer/src/Builder/ReportBuilder.php
+++ b/writer/src/Builder/ReportBuilder.php
@@ -97,6 +97,9 @@ class ReportBuilder
      *
      * Non-nullable return type: to no-op, return the input unchanged.
      *
+     * SECURITY: code-only API. Never construct $callback from data (JSON/DB/HTTP)
+     * via Closure::fromCallable() or dynamic dispatch — see security-scanner R5.
+     *
      * @param callable(array): array $callback
      */
     public function beforeBuild(callable $callback): self
@@ -113,6 +116,9 @@ class ReportBuilder
      * Immutable-fluent: returns a clone. Callers MUST reassign.
      *
      * Non-nullable return type: to no-op, return the input unchanged.
+     *
+     * SECURITY: code-only API. Never construct $callback from data (JSON/DB/HTTP)
+     * via Closure::fromCallable() or dynamic dispatch — see security-scanner R5.
      *
      * @param callable(ReportInstance): ReportInstance $callback
      */
@@ -136,6 +142,9 @@ class ReportBuilder
      * null the band is suppressed and remaining callbacks are skipped.
      *
      * Immutable-fluent: returns a clone. Callers MUST reassign.
+     *
+     * SECURITY: code-only API. Never construct $callback from data (JSON/DB/HTTP)
+     * via Closure::fromCallable() or dynamic dispatch — see security-scanner R5.
      *
      * @param callable(BandInstance, BandContext): ?BandInstance $callback
      */

--- a/writer/src/Fill/DefinitionFiller.php
+++ b/writer/src/Fill/DefinitionFiller.php
@@ -24,6 +24,10 @@ class DefinitionFiller implements ReportFillerInterface
     private FormatterRegistry $formatters;
     /** @var array<string, callable[]> keyed by band definition id */
     private array $bandCallbacks = [];
+    /** @var callable[] */
+    private array $beforeFillCallbacks = [];
+    /** @var callable[] */
+    private array $afterFillCallbacks = [];
     /** @var array<string, array<int, array<string, mixed>>> */
     private array $rowCache = [];
 
@@ -45,21 +49,74 @@ class DefinitionFiller implements ReportFillerInterface
      * Callbacks chain: each receives the output of the previous. If any returns null
      * the band is suppressed and remaining callbacks are skipped.
      *
-     * This method mutates $this — it is NOT fluent. Call it and discard the return.
+     * Immutable-fluent: returns a clone. Callers MUST reassign
+     * (`$filler = $filler->onBand(...)`); fire-and-forget silently drops the callback.
      *
      * @param callable(BandInstance, BandContext): ?BandInstance $callback
      */
-    public function onBand(string $bandId, callable $callback): void
+    public function onBand(string $bandId, callable $callback): self
     {
-        $this->bandCallbacks[$bandId][] = $callback;
+        $clone = clone $this;
+        $clone->bandCallbacks[$bandId][] = $callback;
+        return $clone;
+    }
+
+    /**
+     * Register a callback that fires before the data source is queried, receiving
+     * the params array and returning a (possibly transformed) params array.
+     *
+     * Immutable-fluent: returns a clone. Callers MUST reassign. Chain via
+     * registration order — each callback receives the output of the previous.
+     *
+     * Non-nullable return type: to no-op, return the input unchanged. Returning
+     * null (or forgetting to return) raises TypeError at the next reducer step.
+     *
+     * @param callable(array): array $callback
+     */
+    public function beforeFill(callable $callback): self
+    {
+        $clone = clone $this;
+        $clone->beforeFillCallbacks[] = $callback;
+        return $clone;
+    }
+
+    /**
+     * Register a callback that fires after all bands are built, just before
+     * `fill()` returns. Receives the ReportInstance and returns a (possibly
+     * transformed) ReportInstance.
+     *
+     * Immutable-fluent: returns a clone. Callers MUST reassign. Chain via
+     * registration order — each callback receives the output of the previous.
+     *
+     * Non-nullable return type: to no-op, return the input unchanged.
+     *
+     * @param callable(ReportInstance): ReportInstance $callback
+     */
+    public function afterFill(callable $callback): self
+    {
+        $clone = clone $this;
+        $clone->afterFillCallbacks[] = $callback;
+        return $clone;
     }
 
     public function fill(array $params): ReportInstance
     {
+        $params = array_reduce(
+            $this->beforeFillCallbacks,
+            fn ($acc, $cb) => $cb($acc),
+            $params
+        );
+
         $this->validateParams($params);
         $this->rowCache = [];
         $bands = $this->buildBands($params);
-        return new ReportInstance($this->template->getReportDefinitionId(), $bands);
+        $instance = new ReportInstance($this->template->getReportDefinitionId(), $bands);
+
+        return array_reduce(
+            $this->afterFillCallbacks,
+            fn ($acc, $cb) => $cb($acc),
+            $instance
+        );
     }
 
     // ── Band building ─────────────────────────────────────────────────────────

--- a/writer/src/Fill/DefinitionFiller.php
+++ b/writer/src/Fill/DefinitionFiller.php
@@ -52,6 +52,9 @@ class DefinitionFiller implements ReportFillerInterface
      * Immutable-fluent: returns a clone. Callers MUST reassign
      * (`$filler = $filler->onBand(...)`); fire-and-forget silently drops the callback.
      *
+     * SECURITY: code-only API. Never construct $callback from data (JSON/DB/HTTP)
+     * via Closure::fromCallable() or dynamic dispatch — see security-scanner R5.
+     *
      * @param callable(BandInstance, BandContext): ?BandInstance $callback
      */
     public function onBand(string $bandId, callable $callback): self
@@ -71,6 +74,13 @@ class DefinitionFiller implements ReportFillerInterface
      * Non-nullable return type: to no-op, return the input unchanged. Returning
      * null (or forgetting to return) raises TypeError at the next reducer step.
      *
+     * SECURITY: code-only API. Never construct $callback from data (JSON/DB/HTTP)
+     * via Closure::fromCallable() or dynamic dispatch — see security-scanner R5.
+     *
+     * NOTE: beforeFill runs BEFORE validateParams(). Hook authors should not
+     * assume required params are present or well-typed — a hook may itself
+     * install required defaults, but must be defensive on read.
+     *
      * @param callable(array): array $callback
      */
     public function beforeFill(callable $callback): self
@@ -89,6 +99,9 @@ class DefinitionFiller implements ReportFillerInterface
      * registration order — each callback receives the output of the previous.
      *
      * Non-nullable return type: to no-op, return the input unchanged.
+     *
+     * SECURITY: code-only API. Never construct $callback from data (JSON/DB/HTTP)
+     * via Closure::fromCallable() or dynamic dispatch — see security-scanner R5.
      *
      * @param callable(ReportInstance): ReportInstance $callback
      */

--- a/writer/tests/Unit/Builder/ReportBuilderHooksTest.php
+++ b/writer/tests/Unit/Builder/ReportBuilderHooksTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\Tests\Unit\Builder;
+
+use ReportWriter\Builder\Column;
+use ReportWriter\Builder\ReportBuilder;
+use ReportWriter\Instance\BandInstance;
+use ReportWriter\Instance\ReportInstance;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the extension hooks API on ReportBuilder:
+ *  - beforeBuild: receives rows array, chains, throws propagate
+ *  - afterBuild:  receives ReportInstance, chains, throws propagate
+ *  - onBand:      band-type keyed, chains, null suppresses, immutable
+ */
+class ReportBuilderHooksTest extends TestCase
+{
+    private function itemCol(): Column
+    {
+        return Column::make('item', 'Item', 0.0, 200.0);
+    }
+
+    private function totalCol(): Column
+    {
+        return Column::make('total', 'Total', 200.0, 100.0);
+    }
+
+    private function baseBuilder(): ReportBuilder
+    {
+        return ReportBuilder::create('test_report')
+            ->columns([$this->itemCol(), $this->totalCol()]);
+    }
+
+    private function row(string $item, float $total, string $category = ''): array
+    {
+        return ['item' => $item, 'total' => $total, 'category' => $category];
+    }
+
+    private function bandTypes(ReportInstance $inst): array
+    {
+        return array_map(fn (BandInstance $b) => $b->getBandType(), $inst->getBandInstances());
+    }
+
+    // ── beforeBuild ──────────────────────────────────────────────────────────
+
+    public function testBeforeBuildReceivesRows(): void
+    {
+        $seen   = null;
+        $rows   = [$this->row('a', 1.0), $this->row('b', 2.0)];
+        $result = $this->baseBuilder()
+            ->rows($rows)
+            ->beforeBuild(function (array $r) use (&$seen): array {
+                $seen = $r;
+                return $r;
+            })
+            ->build();
+
+        $this->assertSame($rows, $seen);
+        $this->assertInstanceOf(ReportInstance::class, $result);
+    }
+
+    public function testBeforeBuildTransformationFlowsIntoDetailBands(): void
+    {
+        $instance = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0), $this->row('b', 2.0), $this->row('c', 3.0)])
+            // Filter out one row before build sees it.
+            ->beforeBuild(fn (array $rows): array
+                => array_values(array_filter($rows, fn ($r) => $r['item'] !== 'b')))
+            ->build();
+
+        $detailBands = array_filter(
+            $instance->getBandInstances(),
+            fn (BandInstance $b) => $b->getBandType() === 'detail'
+        );
+        $this->assertCount(2, $detailBands);
+    }
+
+    public function testBeforeBuildChainsInRegistrationOrder(): void
+    {
+        $order = [];
+        $builder = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->beforeBuild(function (array $r) use (&$order): array {
+                $order[] = 'first';
+                $r[] = $this->row('added-by-first', 10.0);
+                return $r;
+            })
+            ->beforeBuild(function (array $r) use (&$order): array {
+                $order[] = 'second';
+                // The second callback observes the row added by the first.
+                $items = array_column($r, 'item');
+                $order[] = 'items:' . implode(',', $items);
+                return $r;
+            });
+
+        $builder->build();
+        $this->assertSame(['first', 'second', 'items:a,added-by-first'], $order);
+    }
+
+    public function testBeforeBuildReturnsCloneNotSelf(): void
+    {
+        $a = $this->baseBuilder();
+        $b = $a->beforeBuild(fn (array $r): array => $r);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testBeforeBuildThrowingPropagates(): void
+    {
+        $builder = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->beforeBuild(function (array $r): array {
+                throw new \RuntimeException('kaboom');
+            });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('kaboom');
+        $builder->build();
+    }
+
+    // ── afterBuild ───────────────────────────────────────────────────────────
+
+    public function testAfterBuildReceivesReportInstance(): void
+    {
+        $seen   = null;
+        $result = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->afterBuild(function (ReportInstance $inst) use (&$seen): ReportInstance {
+                $seen = $inst;
+                return $inst;
+            })
+            ->build();
+
+        $this->assertInstanceOf(ReportInstance::class, $seen);
+        $this->assertSame($seen, $result);
+    }
+
+    public function testAfterBuildTransformationFlowsThrough(): void
+    {
+        $result = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->afterBuild(fn (ReportInstance $inst): ReportInstance
+                => new ReportInstance('replaced', []))
+            ->build();
+
+        $this->assertSame('replaced', $result->getReportInstanceId());
+        $this->assertCount(0, $result->getBandInstances());
+    }
+
+    public function testAfterBuildChainsInRegistrationOrder(): void
+    {
+        $result = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->afterBuild(fn (ReportInstance $inst): ReportInstance
+                => new ReportInstance('first-' . $inst->getReportInstanceId(), $inst->getBandInstances()))
+            ->afterBuild(fn (ReportInstance $inst): ReportInstance
+                => new ReportInstance('second-' . $inst->getReportInstanceId(), $inst->getBandInstances()))
+            ->build();
+
+        $this->assertSame('second-first-test_report', $result->getReportInstanceId());
+    }
+
+    public function testAfterBuildReturnsCloneNotSelf(): void
+    {
+        $a = $this->baseBuilder();
+        $b = $a->afterBuild(fn (ReportInstance $inst): ReportInstance => $inst);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testAfterBuildThrowingPropagates(): void
+    {
+        $builder = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->afterBuild(function (ReportInstance $inst): ReportInstance {
+                throw new \RuntimeException('boom');
+            });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+        $builder->build();
+    }
+
+    public function testAfterBuildTypeErrorWhenCallbackReturnsNull(): void
+    {
+        $builder = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->afterBuild(function (ReportInstance $inst) {
+                return null;
+            });
+
+        $this->expectException(\TypeError::class);
+        $builder->build();
+    }
+
+    // ── onBand ───────────────────────────────────────────────────────────────
+
+    public function testOnBandReturnsCloneNotSelf(): void
+    {
+        $a = $this->baseBuilder();
+        $b = $a->onBand('detail', fn ($band, $ctx) => $band);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testOnBandFiresPerBandTypeForAllDetailRows(): void
+    {
+        $seen = [];
+        $this->baseBuilder()
+            ->rows([$this->row('a', 1.0), $this->row('b', 2.0), $this->row('c', 3.0)])
+            ->onBand('detail', function ($band, $ctx) use (&$seen) {
+                $seen[] = $ctx->getRow()['item'];
+                return $band;
+            })
+            ->build();
+
+        // Single registration keyed by band-type — fires once per detail row.
+        $this->assertSame(['a', 'b', 'c'], $seen);
+    }
+
+    public function testOnBandNullSuppressesDetailBand(): void
+    {
+        $instance = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0), $this->row('b', 2.0), $this->row('c', 3.0)])
+            ->onBand('detail', fn ($band, $ctx) => $ctx->getRow()['item'] === 'b' ? null : $band)
+            ->build();
+
+        $detailBands = array_filter(
+            $instance->getBandInstances(),
+            fn (BandInstance $b) => $b->getBandType() === 'detail'
+        );
+        $this->assertCount(2, $detailBands);
+    }
+
+    public function testOnBandNullSuppressesTitleBand(): void
+    {
+        $instance = $this->baseBuilder()
+            ->title('My Report')
+            ->rows([$this->row('a', 1.0)])
+            ->onBand('title', fn ($band, $ctx) => null)
+            ->build();
+
+        $this->assertNotContains('title', $this->bandTypes($instance));
+    }
+
+    public function testOnBandNullSuppressesSummaryBand(): void
+    {
+        $instance = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->onBand('summary', fn ($band, $ctx) => null)
+            ->build();
+
+        $this->assertNotContains('summary', $this->bandTypes($instance));
+    }
+
+    public function testOnBandNullSuppressesGroupHeaderAndFooter(): void
+    {
+        $instance = $this->baseBuilder()
+            ->rows([
+                $this->row('a', 1.0, 'X'),
+                $this->row('b', 2.0, 'Y'),
+            ])
+            ->groupBy('category')
+            ->onBand('group-header', fn ($band, $ctx) => null)
+            ->onBand('group-footer', fn ($band, $ctx) => null)
+            ->build();
+
+        $types = $this->bandTypes($instance);
+        $this->assertNotContains('group-header', $types);
+        $this->assertNotContains('group-footer', $types);
+    }
+
+    public function testOnBandGroupHeaderContextCarriesGroupValueAndRows(): void
+    {
+        $captures = [];
+        $this->baseBuilder()
+            ->rows([
+                $this->row('a', 1.0, 'X'),
+                $this->row('b', 2.0, 'X'),
+                $this->row('c', 3.0, 'Y'),
+            ])
+            ->groupBy('category')
+            ->onBand('group-header', function ($band, $ctx) use (&$captures) {
+                $captures[] = [
+                    'groupValue' => $ctx->getGroupValue(),
+                    'rowCount'   => count($ctx->getAggregateRows()),
+                ];
+                return $band;
+            })
+            ->build();
+
+        $this->assertSame(
+            [
+                ['groupValue' => 'X', 'rowCount' => 2],
+                ['groupValue' => 'Y', 'rowCount' => 1],
+            ],
+            $captures
+        );
+    }
+
+    public function testOnBandCallbacksChainInRegistrationOrder(): void
+    {
+        $log = [];
+        $instance = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'first'; return $band; })
+            ->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'second'; return null; })
+            ->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'third'; return $band; })
+            ->build();
+
+        $this->assertSame(['first', 'second'], $log, 'Chain stops at first null');
+        $detailBands = array_filter(
+            $instance->getBandInstances(),
+            fn (BandInstance $b) => $b->getBandType() === 'detail'
+        );
+        $this->assertCount(0, $detailBands);
+    }
+
+    public function testOnBandThrowingPropagates(): void
+    {
+        $builder = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->onBand('detail', function ($band, $ctx): BandInstance {
+                throw new \RuntimeException('bandboom');
+            });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('bandboom');
+        $builder->build();
+    }
+
+    public function testOnBandUnregisteredTypeIsNoOp(): void
+    {
+        // Registering for a band-type that never appears (no title set)
+        // must not error and must not affect other bands.
+        $instance = $this->baseBuilder()
+            ->rows([$this->row('a', 1.0)])
+            ->onBand('title', fn ($band, $ctx) => null)
+            ->build();
+
+        // Detail + col-header + summary still present; no title band existed.
+        $types = $this->bandTypes($instance);
+        $this->assertContains('col-header', $types);
+        $this->assertContains('detail', $types);
+        $this->assertContains('summary', $types);
+    }
+
+    public function testOnBandDoesNotMutateOriginalBuilder(): void
+    {
+        $a = $this->baseBuilder()->rows([$this->row('a', 1.0)]);
+        $b = $a->onBand('detail', fn ($band, $ctx) => null);
+
+        $aBands = array_filter(
+            $a->build()->getBandInstances(),
+            fn (BandInstance $band) => $band->getBandType() === 'detail'
+        );
+        $bBands = array_filter(
+            $b->build()->getBandInstances(),
+            fn (BandInstance $band) => $band->getBandType() === 'detail'
+        );
+
+        $this->assertCount(1, $aBands, 'Original builder unaffected');
+        $this->assertCount(0, $bBands, 'Clone carries the suppression');
+    }
+}

--- a/writer/tests/Unit/Fill/DefinitionFillerHooksTest.php
+++ b/writer/tests/Unit/Fill/DefinitionFillerHooksTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\Tests\Unit\Fill;
+
+use ReportWriter\Fill\BandContext;
+use ReportWriter\Fill\DefinitionFiller;
+use ReportWriter\Instance\BandInstance;
+use ReportWriter\Instance\ReportInstance;
+use ReportWriter\Interfaces\ReportDataSourceInterface;
+use ReportWriter\Registry\DataSourceRegistry;
+use ReportWriter\Registry\FormatterRegistry;
+use ReportWriter\Template\TemplateLoader;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the extension hooks API on DefinitionFiller:
+ *  - retrofit: onBand is truly immutable-fluent (returns `: self`, clones)
+ *  - beforeFill: receives params, chains, throws propagate
+ *  - afterFill:  receives ReportInstance, chains, throws propagate
+ */
+class DefinitionFillerHooksTest extends TestCase
+{
+    private TemplateLoader $loader;
+    private FormatterRegistry $formatters;
+
+    protected function setUp(): void
+    {
+        $this->loader     = new TemplateLoader();
+        $this->formatters = FormatterRegistry::defaults();
+    }
+
+    private function makeSource(array $rows): ReportDataSourceInterface
+    {
+        return new class($rows) implements ReportDataSourceInterface {
+            private array $rows;
+            public function __construct(array $rows) { $this->rows = $rows; }
+            public function fetchRows(array $params): array { return $this->rows; }
+        };
+    }
+
+    private function filler(array $templateData, array $rows): DefinitionFiller
+    {
+        $registry = new DataSourceRegistry();
+        $registry->register($templateData['data_source'], $this->makeSource($rows));
+        return new DefinitionFiller(
+            $this->loader->loadFromArray($templateData),
+            $registry,
+            $this->formatters
+        );
+    }
+
+    private function detailTemplate(): array
+    {
+        return [
+            'report_definition_id' => 'test',
+            'data_source'          => 'src',
+            'bands'                => [
+                [
+                    'id' => 'detail', 'type' => 'detail',
+                    'elements' => [
+                        ['id' => 'name', 'x' => 0, 'width' => 100, 'height' => 12,
+                         'content' => ['type' => 'field', 'field' => 'name']],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    // ── onBand immutability retrofit ─────────────────────────────────────────
+
+    public function testOnBandReturnsCloneNotSelf(): void
+    {
+        $a = $this->filler($this->detailTemplate(), [['name' => 'x']]);
+        $b = $a->onBand('detail', fn ($band, $ctx) => $band);
+
+        $this->assertNotSame($a, $b, 'onBand must return a clone, not $this');
+        $this->assertInstanceOf(DefinitionFiller::class, $b);
+    }
+
+    public function testOnBandDoesNotMutateOriginal(): void
+    {
+        $a = $this->filler($this->detailTemplate(), [['name' => 'x']]);
+        // Register a suppress-all callback on the clone.
+        $b = $a->onBand('detail', fn ($band, $ctx) => null);
+
+        // Original filler must still emit the detail band — its bandCallbacks
+        // property is unchanged because the clone got the mutation.
+        $aBands = $a->fill([])->getBandInstances();
+        $this->assertCount(1, $aBands, 'Original filler must be unaffected by mutation on the clone');
+
+        // Clone suppresses.
+        $bBands = $b->fill([])->getBandInstances();
+        $this->assertCount(0, $bBands, 'Clone must reflect the registered suppress callback');
+    }
+
+    public function testFireAndForgetOnBandSilentlyDropsCallback(): void
+    {
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']]);
+        // Discarding the return of onBand loses the registration — this is the
+        // load-bearing consequence of immutable-fluent semantics.
+        $filler->onBand('detail', fn ($band, $ctx) => null);
+
+        $bands = $filler->fill([])->getBandInstances();
+        $this->assertCount(1, $bands, 'Discarded clone must not affect original');
+    }
+
+    // ── beforeFill ───────────────────────────────────────────────────────────
+
+    public function testBeforeFillReceivesParams(): void
+    {
+        $seen = null;
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']])
+            ->beforeFill(function (array $params) use (&$seen): array {
+                $seen = $params;
+                return $params;
+            });
+
+        $filler->fill(['foo' => 'bar']);
+        $this->assertSame(['foo' => 'bar'], $seen);
+    }
+
+    public function testBeforeFillTransformationFlowsToParamValidation(): void
+    {
+        $tmpl = $this->detailTemplate();
+        $tmpl['params'] = ['courseId' => ['type' => 'int', 'required' => true]];
+
+        // Callback injects the required param — validation should now pass.
+        $filler = $this->filler($tmpl, [['name' => 'x']])
+            ->beforeFill(fn (array $params): array => $params + ['courseId' => 42]);
+
+        $instance = $filler->fill([]);
+        $this->assertInstanceOf(ReportInstance::class, $instance);
+    }
+
+    public function testBeforeFillChainsInRegistrationOrder(): void
+    {
+        $order = [];
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']])
+            ->beforeFill(function (array $p) use (&$order): array {
+                $order[] = 'first';
+                $p['seen'] = ($p['seen'] ?? '') . 'A';
+                return $p;
+            })
+            ->beforeFill(function (array $p) use (&$order): array {
+                $order[] = 'second';
+                $p['seen'] = ($p['seen'] ?? '') . 'B';
+                return $p;
+            });
+
+        // Third callback observes the concatenation from the first two.
+        $observed = null;
+        $filler = $filler->beforeFill(function (array $p) use (&$observed): array {
+            $observed = $p['seen'] ?? null;
+            return $p;
+        });
+
+        $filler->fill([]);
+        $this->assertSame(['first', 'second'], $order);
+        $this->assertSame('AB', $observed);
+    }
+
+    public function testBeforeFillReturnsCloneNotSelf(): void
+    {
+        $a = $this->filler($this->detailTemplate(), [['name' => 'x']]);
+        $b = $a->beforeFill(fn (array $p): array => $p);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testBeforeFillThrowingPropagates(): void
+    {
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']])
+            ->beforeFill(function (array $p): array {
+                throw new \RuntimeException('kaboom');
+            });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('kaboom');
+        $filler->fill([]);
+    }
+
+    // ── afterFill ────────────────────────────────────────────────────────────
+
+    public function testAfterFillReceivesReportInstance(): void
+    {
+        $seen = null;
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']])
+            ->afterFill(function (ReportInstance $inst) use (&$seen): ReportInstance {
+                $seen = $inst;
+                return $inst;
+            });
+
+        $result = $filler->fill([]);
+        $this->assertInstanceOf(ReportInstance::class, $seen);
+        $this->assertSame($seen, $result);
+    }
+
+    public function testAfterFillTransformationFlowsThrough(): void
+    {
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']])
+            ->afterFill(function (ReportInstance $inst): ReportInstance {
+                // Return an entirely new instance with no bands.
+                return new ReportInstance($inst->getReportInstanceId(), []);
+            });
+
+        $instance = $filler->fill([]);
+        $this->assertCount(0, $instance->getBandInstances());
+    }
+
+    public function testAfterFillChainsInRegistrationOrder(): void
+    {
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']])
+            ->afterFill(fn (ReportInstance $inst): ReportInstance
+                => new ReportInstance('first-' . $inst->getReportInstanceId(), $inst->getBandInstances()))
+            ->afterFill(fn (ReportInstance $inst): ReportInstance
+                => new ReportInstance('second-' . $inst->getReportInstanceId(), $inst->getBandInstances()));
+
+        $instance = $filler->fill([]);
+        $this->assertSame('second-first-test', $instance->getReportInstanceId());
+    }
+
+    public function testAfterFillReturnsCloneNotSelf(): void
+    {
+        $a = $this->filler($this->detailTemplate(), [['name' => 'x']]);
+        $b = $a->afterFill(fn (ReportInstance $inst): ReportInstance => $inst);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testAfterFillThrowingPropagates(): void
+    {
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']])
+            ->afterFill(function (ReportInstance $inst): ReportInstance {
+                throw new \RuntimeException('boom');
+            });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+        $filler->fill([]);
+    }
+
+    public function testAfterFillTypeErrorWhenCallbackReturnsNull(): void
+    {
+        // Non-nullable return type; TypeError on the reducer step that
+        // consumes the null result.
+        $filler = $this->filler($this->detailTemplate(), [['name' => 'x']])
+            ->afterFill(function (ReportInstance $inst) {
+                return null;
+            });
+
+        $this->expectException(\TypeError::class);
+        $filler->fill([]);
+    }
+}

--- a/writer/tests/Unit/Fill/DefinitionFillerTest.php
+++ b/writer/tests/Unit/Fill/DefinitionFillerTest.php
@@ -309,7 +309,7 @@ class DefinitionFillerTest extends TestCase
             ['amount' => 0],
             ['amount' => 5],
         ]);
-        $filler->onBand('detail', function ($band, $ctx) {
+        $filler = $filler->onBand('detail', function ($band, $ctx) {
             return $ctx->getRow()['amount'] === 0 ? null : $band;
         });
 
@@ -330,7 +330,7 @@ class DefinitionFillerTest extends TestCase
 
         $seen = [];
         $filler = $this->filler($tmpl, [['name' => 'Alpha'], ['name' => 'Beta']]);
-        $filler->onBand('detail', function ($band, $ctx) use (&$seen) {
+        $filler = $filler->onBand('detail', function ($band, $ctx) use (&$seen) {
             $seen[] = $ctx->getRow()['name'];
             return $band;
         });
@@ -362,7 +362,7 @@ class DefinitionFillerTest extends TestCase
             ['cat' => 'A', 'amount' => 1],
             ['cat' => 'B', 'amount' => 2],
         ]);
-        $filler->onBand('grp_hdr', function ($band, $ctx) use (&$seen) {
+        $filler = $filler->onBand('grp_hdr', function ($band, $ctx) use (&$seen) {
             $seen[] = $ctx->getGroupValue();
             return $band;
         });
@@ -384,9 +384,9 @@ class DefinitionFillerTest extends TestCase
 
         $log = [];
         $filler = $this->filler($tmpl, [['name' => 'X']]);
-        $filler->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'first'; return $band; });
-        $filler->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'second'; return null; });
-        $filler->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'third'; return $band; });
+        $filler = $filler->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'first'; return $band; });
+        $filler = $filler->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'second'; return null; });
+        $filler = $filler->onBand('detail', function ($band, $ctx) use (&$log) { $log[] = 'third'; return $band; });
 
         $bands = $filler->fill([])->getBandInstances();
         $this->assertCount(0, $bands);
@@ -405,7 +405,7 @@ class DefinitionFillerTest extends TestCase
         ];
 
         $filler = $this->filler($tmpl, []);
-        $filler->onBand('title', fn($band, $ctx) => null);
+        $filler = $filler->onBand('title', fn($band, $ctx) => null);
 
         $this->assertCount(0, $filler->fill([])->getBandInstances());
     }
@@ -424,7 +424,7 @@ class DefinitionFillerTest extends TestCase
         $rows = [['amount' => 10], ['amount' => 20]];
         $seen = [];
         $filler = $this->filler($tmpl, $rows);
-        $filler->onBand('summary', function ($band, $ctx) use (&$seen) {
+        $filler = $filler->onBand('summary', function ($band, $ctx) use (&$seen) {
             $seen = $ctx->getAggregateRows();
             return $band;
         });


### PR DESCRIPTION
## Summary

Implements the extension-hooks API locked in [docs/architecture/extension-hooks.md](docs/architecture/extension-hooks.md). Adds 5 new hook methods across ReportBuilder + DefinitionFiller, plus a retrofit to make DefinitionFiller::onBand truly immutable.

**Retrofit:**
- \`DefinitionFiller::onBand\` goes from \`: void\` (A1 Ticket 006 hasty fix) back to \`: self\`, but this time honestly immutable via clone-and-return. 6 existing test call sites updated from fire-and-forget to reassignment.

**New lifecycle hooks** (all immutable-fluent, chain via \`array_reduce\`):
- \`ReportBuilder::beforeBuild(callable(array \$rows): array): self\`
- \`ReportBuilder::afterBuild(callable(ReportInstance): ReportInstance): self\`
- \`ReportBuilder::onBand(string, callable(BandInstance, BandContext): ?BandInstance): self\` — NEW, mirrors DefinitionFiller's convention (keys by band-type string, not per-instance ID; null return suppresses the band from the output)
- \`DefinitionFiller::beforeFill(callable(array \$params): array): self\` — fires BEFORE data-source query and BEFORE validateParams (documented in docblock)
- \`DefinitionFiller::afterFill(callable(ReportInstance): ReportInstance): self\` — fires just before \`fill()\` returns

**Return-type discipline:**
- Lifecycle hooks are non-nullable (\`: array\`, \`: ReportInstance\`) — no-op = return input unchanged. Forgotten return → TypeError. Loud failure preferred over silent no-op.
- Only \`onBand\` accepts \`?BandInstance\` — null is load-bearing (suppresses the band). Reserving \`null\` semantics to onBand keeps its meaning unambiguous.

**Security hardening** (second commit, security-scanner follow-up):
- Every hook method carries a \`SECURITY: code-only API\` docblock preventing future drift toward JSON-derived callables (R5 protection).
- \`beforeFill\` docblock notes it runs BEFORE \`validateParams()\` — hook authors must not assume required params are present.

## Test evidence

- **Library suite: 122 → 158 tests (287 assertions), all green.** +36 new tests split across:
  - \`writer/tests/Unit/Fill/DefinitionFillerHooksTest.php\` — 14 tests (retrofit immutability, fire-and-forget-drops-callback, beforeFill/afterFill happy-path + chaining + throw propagation)
  - \`writer/tests/Unit/Builder/ReportBuilderHooksTest.php\` — 22 tests (beforeBuild/afterBuild transform + chain, onBand per-band-type + null-suppress + context payload, immutability, TypeError on missing return)
- \`writer-app\` suite: 30 tests unchanged.
- Passed spec-compliance review + \`.claude/agents/dry-solid-reviewer\` review + \`.claude/agents/security-scanner\` scan.

## Test plan for reviewer

- [ ] \`cd writer && composer install && vendor/bin/phpunit\` — 158 green
- [ ] \`cd writer-app && composer install && vendor/bin/phpunit\` — 30 green (regression check — hooks are additive)
- [ ] Spot-check retrofit: \`grep 'onBand.*: void' writer/src/Fill/DefinitionFiller.php\` — expected zero matches
- [ ] Spot-check: \`grep 'usableHeight' writer\` — expected zero matches (from Ticket 018 also-landed)

## Follow-up items surfaced during review

**Rule-of-Three watch — HooksTrait extraction:** \`DefinitionFiller\` and \`ReportBuilder\` now share the same shape (bandCallbacks field + onBand registrar + applyCallbacks helper). Two shipped classes. Design doc defers extraction to \"when 2+ CUSTOM fillers reimplement the same shape\". If a third band-hook-capable class lands (custom filler, SubreportFiller, etc.), extract to \`writer/src/Fill/HooksTrait.php\` or a \`Fill/BandCallbacks\` value object composed into both.

**Non-blocking security-scanner observation** (already applied):
- Every hook method carries a SECURITY docblock line to prevent future drift toward building callbacks from JSON/DB/HTTP inputs.

## Related

- Ticket [016](docs/tickets/016-extension-hooks-lifecycle-plus-immutability-retrofit.md) — self-closing (implementation lands in this PR)
- Partially reverses Ticket [006](docs/tickets/006-definitionfiller-onband-immutability.md) — that ticket dropped the fluent return to \`: void\` in A1 as a hasty fix; this PR restores \`: self\` with proper immutability
- Supersedes Ticket [015](docs/tickets/015-implement-user-scripting.md) design (already marked superseded 2026-08-23)
- Design spec: [docs/architecture/extension-hooks.md](docs/architecture/extension-hooks.md)