### PR TITLE
chore(docs): refresh ticket ledger; close Ticket 009 as verified

### DIFF
--- a/docs/tickets/009-verify-page-margin-print-rule.md
+++ b/docs/tickets/009-verify-page-margin-print-rule.md
@@ -1,5 +1,6 @@
 # TICKET-009: Verify or add `@page { margin: 0 }` for print output
 
+**Status:** ✅ Closed (2026-08-23) — verified already present at `HtmlRenderer.php:161`
 **Priority:** Low
 **Source:** frontend-designer audit (2026-08-22) — 🟡 Print behavior audit
 **Scope:** `writer/src/Renderer/HtmlRenderer.php` head block, potentially `frontend/src/App.vue` global styles
@@ -45,3 +46,13 @@ If we want defence-in-depth, add the same rule to `App.vue`'s `@media print` blo
 ## Notes
 
 - Currently `HtmlRenderer::head()` DOES include `@page { margin: 0 }` at line 161 — [verify]. If confirmed, this ticket becomes doc-only (add a note in `docs/04-pipeline/04-render.md` when that page is written).
+
+## Resolution
+
+Verified 2026-08-23 (part of PR A backlog-sweep). `HtmlRenderer::head()` emits
+`@page { margin: 0 }` inside its `@media print{...}` block at line 161. The
+rule ships with every rendered report; the frontend viewer inherits it via
+the extracted `<style>` blocks. No code change required. Frontend defence-in-depth
+in `App.vue`'s `@media print` block was intentionally skipped — the server-side
+rule is sufficient, and duplicating it in two places creates a drift hazard.
+The `docs/04-pipeline/04-render.md` note stays deferred until that page exists.

--- a/docs/tickets/012-implement-standalone-runtime-subproject-a.md
+++ b/docs/tickets/012-implement-standalone-runtime-subproject-a.md
@@ -2,7 +2,7 @@
 
 **Priority:** Epic — highest-level active initiative
 **Source:** session-design (2026-08-22) — brainstorming output
-**Status:** Blocked on remaining design Sections 5–6, then produces an implementation plan
+**Status:** In progress — A1 + A2 shipped 2026-08-22; A3–A7 remaining
 **Scope:** Whole `writer-app/` directory (new), `frontend/` additions (router + Builder page + CodeMirror + state), `docker-compose.yml`, `docker/`, updates to `writer/` (via [Ticket 010](010-library-rename-to-edgecase.md))
 
 ## Problem

--- a/docs/tickets/016-extension-hooks-lifecycle-plus-immutability-retrofit.md
+++ b/docs/tickets/016-extension-hooks-lifecycle-plus-immutability-retrofit.md
@@ -1,6 +1,6 @@
 # TICKET-016: Add lifecycle hooks to ReportBuilder + DefinitionFiller (immutable-fluent), retrofit `onBand` immutability
 
-**Status:** Open — design captured in `docs/architecture/extension-hooks.md`
+**Status:** ✅ Closed (2026-08-23) — shipped via PR #9 (`03634a2`)
 **Priority:** Medium (unblocks host apps that want lifecycle transforms without subclassing the shipped fillers)
 **Source:** design session 2026-08-23 — the "collapse user-scripting to hooks + named strategies" pivot
 **Scope:** `writer/src/Builder/ReportBuilder.php`, `writer/src/Fill/DefinitionFiller.php`, `writer/tests/**/*.php`
@@ -92,3 +92,14 @@ Callbacks that throw propagate up through `build()` / `fill()`. No try/catch in 
 - Supersedes: [Ticket 015](015-implement-user-scripting.md) — user-scripting design pivoted 2026-08-23 to hooks + named strategies; user-scripting.md marked superseded, extension-hooks.md replaces it
 - Partially reverses: [Ticket 006](006-definitionfiller-onband-immutability.md) — closed in A1 by dropping fluent return to `void`; now the honest fix (true immutability with `: self`) is applied
 - Design spec: `docs/architecture/extension-hooks.md`
+
+## Resolution
+
+Shipped 2026-08-23 via PR #9 (merge commit `03634a2`). Both `ReportBuilder`
+and `DefinitionFiller` gained 5 lifecycle hooks (`beforeFill`/`afterFill`
+on filler; `beforeBuild`/`afterBuild` on builder; `onBand` on both) with
+the immutable-fluent convention. `DefinitionFiller::onBand` was retrofitted
+from `: void` back to `: self` with clone-and-return semantics (properly
+immutable this time — supersedes Ticket 006's stopgap). 36 new tests added.
+Security docblocks (R5: code-only API, never construct callables from data)
+were added in a follow-up commit `f900919`.

--- a/docs/tickets/README.md
+++ b/docs/tickets/README.md
@@ -16,14 +16,14 @@ Local ticket store — GitHub-issue-shaped so each file can be promoted to `edge
 | [006](006-definitionfiller-onband-immutability.md) | Fix `DefinitionFiller::onBand` fluent-returns-but-mutates | Medium | dry-solid-reviewer | ✅ Closed (A1) |
 | [007](007-zoom-transform-origin-scroll-bug.md) | Fix zoom transform-origin causing unreachable overflow at >100% | Medium | frontend-designer | Open |
 | [008](008-add-vue-tsc-typecheck-step.md) | Add `vue-tsc --noEmit` step to `npm run build` | Medium | frontend-designer | Open |
-| [009](009-verify-page-margin-print-rule.md) | Verify or add `@page { margin: 0 }` for print output | Low | frontend-designer | Open |
+| [009](009-verify-page-margin-print-rule.md) | Verify or add `@page { margin: 0 }` for print output | Low | frontend-designer | ✅ Closed (2026-08-23) |
 | [010](010-library-rename-to-edgecase.md) | Rename library from `foreup/reporting` → `edgecase123/report-writer` | Medium | session-design | ✅ Closed (A1) |
 | [011](011-zoom-preset-placeholder-behavior.md) | Zoom preset dropdown — decide on placeholder behavior | Low | frontend-designer | Open |
-| [012](012-implement-standalone-runtime-subproject-a.md) | Implement standalone runtime (Sub-project A) per approved design | Epic | session-design | Blocked on A1 landing (done) → ready to plan A2 |
+| [012](012-implement-standalone-runtime-subproject-a.md) | Implement standalone runtime (Sub-project A) per approved design | Epic | session-design | In progress — A1 + A2 shipped 2026-08-22; A3–A7 remaining |
 | [013](013-brainstorm-structured-form-builder-subproject-b.md) | Brainstorm structured form builder (Sub-project B) | Epic | session-design | Blocked on Sub-project A |
 | [014](014-implement-v1-layout-engine.md) | Implement v1 layout engine per `docs/architecture/` specs | Epic | design | Backlog |
 | [015](015-implement-user-scripting.md) | Implement user-scripting per `docs/architecture/user-scripting.md` | Epic | design | ❌ Superseded 2026-08-23 by extension-hooks.md + Ticket 016 |
-| [016](016-extension-hooks-lifecycle-plus-immutability-retrofit.md) | Add lifecycle hooks to ReportBuilder + DefinitionFiller (immutable-fluent); retrofit `onBand` immutability | Medium | design session 2026-08-23 | Open |
+| [016](016-extension-hooks-lifecycle-plus-immutability-retrofit.md) | Add lifecycle hooks to ReportBuilder + DefinitionFiller (immutable-fluent); retrofit `onBand` immutability | Medium | design session 2026-08-23 | ✅ Closed (2026-08-23) |
 | [017](017-title-alignment-vs-columns-vs-page.md) | Title element width — columns extent vs printable page width | Low | design 2026-08-23 | ✅ Closed (2026-08-23) |
 | [018](018-pageconfig-right-margin-and-printable-width.md) | PageConfig missing right margin and printableWidth() | Medium | design 2026-08-23 | ✅ Closed (2026-08-23) |
 


### PR DESCRIPTION
## Summary

Housekeeping sweep of the ticket ledger to reflect what's actually shipped.

- **Ticket 016** — extension hooks — shipped last session via PR #9 (\`03634a2\`), but the ledger still showed \`Open\`. Flipped to \`✅ Closed (2026-08-23)\`; added a Resolution section to the ticket file mirroring how Ticket 017 was closed.
- **Ticket 012** — Sub-project A epic — status was stuck at \`Blocked on A1 landing (done) → ready to plan A2\` even though A2 shipped 2026-08-22. Updated to \`In progress — A1 + A2 shipped 2026-08-22; A3–A7 remaining\`.
- **Ticket 009** — \`@page { margin: 0 }\` verification — verified the rule is already emitted from \`HtmlRenderer::head()\` at line 161 (inside the \`@media print{...}\` block). No code change needed. Flipped to \`✅ Closed (2026-08-23)\`; added Resolution section documenting the verification and the deliberate choice to skip frontend defence-in-depth (drift hazard > belt-and-braces value).

## Files touched

- \`docs/tickets/README.md\` (3 rows)
- \`docs/tickets/009-verify-page-margin-print-rule.md\` (status header + Resolution section)
- \`docs/tickets/012-implement-standalone-runtime-subproject-a.md\` (status header)
- \`docs/tickets/016-extension-hooks-lifecycle-plus-immutability-retrofit.md\` (status header + Resolution section)

## Test plan

- [x] No code changes; test suites unchanged (163 writer + 30 writer-app were green pre-PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)