### PR TITLE
refactor(writer): library DRY sweep (Tickets 003 + 004 + 005)

### DIFF
--- a/writer/src/Builder/ReportBuilder.php
+++ b/writer/src/Builder/ReportBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ReportWriter\Builder;
 
+use ReportWriter\Expression\ContentExpression;
 use ReportWriter\Expression\EvalContext;
 use ReportWriter\Expression\StaticExpression;
 use ReportWriter\Fill\BandContext;
@@ -245,32 +246,23 @@ class ReportBuilder
     /** @return ElementInstance[] */
     private function headerElements(): array
     {
-        $elements = [];
-        foreach ($this->columns as $col) {
-            [$elX, $elW] = $this->applyMargin($col);
-            $elements[] = new ElementInstance(
-                'ch_' . $col->getId(), $elX, 0.0, $elW, $this->headerHeight,
-                new TextContent((new StaticExpression($col->getHeader()))->evaluate(new EvalContext())),
-                $col->getTextAlign()
-            );
-        }
-        return $elements;
+        return $this->buildRowElements(
+            'ch',
+            new EvalContext(),
+            fn (Column $col) => new StaticExpression($col->getHeader()),
+            $this->headerHeight
+        );
     }
 
     /** @return ElementInstance[] */
     private function detailElements(string $prefix, array $row): array
     {
-        $ctx      = new EvalContext($row, [], []);
-        $elements = [];
-        foreach ($this->columns as $col) {
-            [$elX, $elW] = $this->applyMargin($col);
-            $elements[] = new ElementInstance(
-                "{$prefix}_{$col->getId()}", $elX, 0.0, $elW, $this->rowHeight,
-                new TextContent($col->getDetailExpr()->evaluate($ctx)),
-                $col->getTextAlign()
-            );
-        }
-        return $elements;
+        return $this->buildRowElements(
+            $prefix,
+            new EvalContext($row, [], []),
+            fn (Column $col) => $col->getDetailExpr(),
+            $this->rowHeight
+        );
     }
 
     /**
@@ -279,19 +271,12 @@ class ReportBuilder
      */
     private function footerElements(string $prefix, array $rows, float $height): array
     {
-        $ctx      = new EvalContext([], $rows, []);
-        $elements = [];
-        foreach ($this->columns as $col) {
-            [$elX, $elW] = $this->applyMargin($col);
-            $expr        = $col->getFooterExpr();
-            $text        = $expr !== null ? $expr->evaluate($ctx) : '';
-            $elements[]  = new ElementInstance(
-                "{$prefix}_{$col->getId()}", $elX, 0.0, $elW, $height,
-                new TextContent($text),
-                $col->getTextAlign()
-            );
-        }
-        return $elements;
+        return $this->buildRowElements(
+            $prefix,
+            new EvalContext([], $rows, []),
+            fn (Column $col) => $col->getFooterExpr(),
+            $height
+        );
     }
 
     /**
@@ -300,14 +285,35 @@ class ReportBuilder
      */
     private function summaryElements(array $rows): array
     {
-        $ctx      = new EvalContext([], $rows, []);
+        return $this->buildRowElements(
+            'summary',
+            new EvalContext([], $rows, []),
+            fn (Column $col) => $col->getSummaryExpr(),
+            $this->summaryHeight
+        );
+    }
+
+    /**
+     * Builds one ElementInstance per column, using $exprFor to select which
+     * expression to evaluate per column. Extracted from the 4 near-identical
+     * *Elements() loops (see Ticket 003).
+     *
+     * @param callable(Column): ?ContentExpression $exprFor
+     * @return ElementInstance[]
+     */
+    private function buildRowElements(
+        string $idPrefix,
+        EvalContext $ctx,
+        callable $exprFor,
+        float $height
+    ): array {
         $elements = [];
         foreach ($this->columns as $col) {
             [$elX, $elW] = $this->applyMargin($col);
-            $expr        = $col->getSummaryExpr();
+            $expr        = $exprFor($col);
             $text        = $expr !== null ? $expr->evaluate($ctx) : '';
             $elements[]  = new ElementInstance(
-                "summary_{$col->getId()}", $elX, 0.0, $elW, $this->summaryHeight,
+                "{$idPrefix}_{$col->getId()}", $elX, 0.0, $elW, $height,
                 new TextContent($text),
                 $col->getTextAlign()
             );

--- a/writer/src/Expression/AbstractFormattableExpression.php
+++ b/writer/src/Expression/AbstractFormattableExpression.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\Expression;
+
+/**
+ * Shared formatter plumbing for expressions that support post-evaluation
+ * formatting. Extracted from FieldExpression, AggregateExpression, and
+ * ComputedExpression (see Ticket 005).
+ *
+ * Concrete subclasses implement evaluate(EvalContext), compute their raw
+ * value, then return $this->applyFormatter($value) as the final step.
+ */
+abstract class AbstractFormattableExpression implements ContentExpression
+{
+    /** @var callable|null */
+    protected $formatter;
+
+    public function withFormatter(callable $fn): self
+    {
+        $clone = clone $this;
+        $clone->formatter = $fn;
+        return $clone;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function applyFormatter($value): string
+    {
+        if ($this->formatter !== null) {
+            return (string) ($this->formatter)($value);
+        }
+        return (string) $value;
+    }
+}

--- a/writer/src/Expression/AggregateExpression.php
+++ b/writer/src/Expression/AggregateExpression.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace ReportWriter\Expression;
 
-final class AggregateExpression implements ContentExpression
+final class AggregateExpression extends AbstractFormattableExpression
 {
     private string $fn;
     private string $field;
-
-    /** @var callable|null */
-    private $formatter;
 
     public function __construct(string $fn, string $field, ?callable $formatter = null)
     {
@@ -19,22 +16,12 @@ final class AggregateExpression implements ContentExpression
         $this->formatter = $formatter;
     }
 
-    public function withFormatter(callable $formatter): self
-    {
-        $clone            = clone $this;
-        $clone->formatter = $formatter;
-        return $clone;
-    }
-
     public function getFn(): string { return $this->fn; }
 
     public function evaluate(EvalContext $ctx): string
     {
         $value = $this->compute($ctx->aggregateRows);
-        if ($this->formatter !== null) {
-            return (string) ($this->formatter)($value);
-        }
-        return (string) $value;
+        return $this->applyFormatter($value);
     }
 
     private function compute(array $rows): float

--- a/writer/src/Expression/ComputedExpression.php
+++ b/writer/src/Expression/ComputedExpression.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace ReportWriter\Expression;
 
-final class ComputedExpression implements ContentExpression
+final class ComputedExpression extends AbstractFormattableExpression
 {
     /** @var callable */
     private $fn;
-
-    /** @var callable|null */
-    private $formatter;
 
     public function __construct(callable $fn, ?callable $formatter = null)
     {
@@ -21,9 +18,6 @@ final class ComputedExpression implements ContentExpression
     public function evaluate(EvalContext $ctx): string
     {
         $value = ($this->fn)($ctx);
-        if ($this->formatter !== null) {
-            return (string) ($this->formatter)($value);
-        }
-        return (string) $value;
+        return $this->applyFormatter($value);
     }
 }

--- a/writer/src/Expression/FieldExpression.php
+++ b/writer/src/Expression/FieldExpression.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace ReportWriter\Expression;
 
-final class FieldExpression implements ContentExpression
+final class FieldExpression extends AbstractFormattableExpression
 {
     private string $field;
-
-    /** @var callable|null */
-    private $formatter;
 
     public function __construct(string $field, ?callable $formatter = null)
     {
@@ -17,19 +14,9 @@ final class FieldExpression implements ContentExpression
         $this->formatter = $formatter;
     }
 
-    public function withFormatter(callable $formatter): self
-    {
-        $clone            = clone $this;
-        $clone->formatter = $formatter;
-        return $clone;
-    }
-
     public function evaluate(EvalContext $ctx): string
     {
         $value = $ctx->row[$this->field] ?? '';
-        if ($this->formatter !== null) {
-            return (string) ($this->formatter)($value);
-        }
-        return (string) $value;
+        return $this->applyFormatter($value);
     }
 }

--- a/writer/src/Fill/DefinitionFiller.php
+++ b/writer/src/Fill/DefinitionFiller.php
@@ -263,30 +263,41 @@ class DefinitionFiller implements ReportFillerInterface
 
     private function staticBand(BandTemplate $def, array $params, ?string $groupValue): BandInstance
     {
-        $bandId   = 'band_' . $def->getId() . ($groupValue !== null ? '_' . $this->safeId($groupValue) : '');
-        $elements = [];
-        foreach ($def->getElements() as $elDef) {
-            $elements[] = $this->resolveElement($elDef, [], [], $groupValue, $params, $bandId);
-        }
-        return new BandInstance($bandId, $def->getType(), $elements, null, $def->getRowSpacing());
+        return $this->buildBand($def, [], [], $groupValue, $params, $groupValue);
     }
 
     private function rowBand(BandTemplate $def, array $row, string $rowKey, array $params): BandInstance
     {
-        $bandId   = 'band_' . $def->getId() . '_' . $this->safeId($rowKey);
-        $elements = [];
-        foreach ($def->getElements() as $elDef) {
-            $elements[] = $this->resolveElement($elDef, $row, [], null, $params, $bandId);
-        }
-        return new BandInstance($bandId, $def->getType(), $elements, null, $def->getRowSpacing());
+        return $this->buildBand($def, $row, [], null, $params, $rowKey);
     }
 
     private function aggregateBand(BandTemplate $def, array $rows, array $params, ?string $groupValue): BandInstance
     {
-        $bandId   = 'band_' . $def->getId() . ($groupValue !== null ? '_' . $this->safeId($groupValue) : '');
+        return $this->buildBand($def, [], $rows, $groupValue, $params, $groupValue);
+    }
+
+    /**
+     * Builds one BandInstance for the given band template. All three
+     * band flavors (static, row, aggregate) funnel through here; each caller
+     * passes the arguments meaningful for its band type and empty defaults
+     * for the rest. Extracted from the 3 near-identical *Band methods
+     * (see Ticket 004).
+     *
+     * @param array<int, array<string, mixed>> $aggregateRows
+     * @param array<string, mixed> $params
+     */
+    private function buildBand(
+        BandTemplate $def,
+        array $row,
+        array $aggregateRows,
+        ?string $groupValue,
+        array $params,
+        ?string $keySuffix
+    ): BandInstance {
+        $bandId   = 'band_' . $def->getId() . ($keySuffix !== null ? '_' . $this->safeId($keySuffix) : '');
         $elements = [];
         foreach ($def->getElements() as $elDef) {
-            $elements[] = $this->resolveElement($elDef, [], $rows, $groupValue, $params, $bandId);
+            $elements[] = $this->resolveElement($elDef, $row, $aggregateRows, $groupValue, $params, $bandId);
         }
         return new BandInstance($bandId, $def->getType(), $elements, null, $def->getRowSpacing());
     }


### PR DESCRIPTION
## Summary

Three low-priority DRY cleanups from the 2026-08-22 dry-solid-reviewer audit, bundled since they're all mechanical, all in \`writer/src/\`, and all behavior-preserving.

- **Ticket 003 — \`buildRowElements()\` in \`ReportBuilder\`.** Collapses \`headerElements\` / \`detailElements\` / \`footerElements\` / \`summaryElements\` (four near-identical loops) into thin wrappers over a single private helper that takes an expression-selector callable + height. Element IDs are byte-identical to pre-refactor.
- **Ticket 004 — \`buildBand()\` in \`DefinitionFiller\`.** Collapses \`staticBand\` / \`rowBand\` / \`aggregateBand\` (three near-identical band constructors) into one shared \`buildBand()\`. The three old method names are kept as thin wrappers so \`buildBands()\` call-sites are untouched. \`bandId\` strings byte-identical.
- **Ticket 005 — \`AbstractFormattableExpression\` extraction.** Pulls the shared \`?callable \$formatter\` field + \`withFormatter()\` clone-on-write + trailing \`applyFormatter()\` block out of \`FieldExpression\` / \`AggregateExpression\` / \`ComputedExpression\`. Option A (abstract base) per the ticket. \`StaticExpression\` deliberately not touched (has no formatter).

## Design docs

- Tickets: \`docs/tickets/003-*.md\`, \`docs/tickets/004-*.md\`, \`docs/tickets/005-*.md\`

## Test plan

- [x] \`cd writer && vendor/bin/phpunit\` — 163 green, 300 assertions. Unchanged from pre-refactor baseline.
- [x] No snapshot changes; no test additions or deletions.

## Non-goals

- Behavior changes of any kind — this is purely structural cleanup.
- Adding new tests — the existing 163 tests already exercise every branch of the refactored code.

## Follow-ups noted by review (not fixed here)

1. **\`withFormatter(): self\` in \`AbstractFormattableExpression\`** — in PHP 7.4, \`self\` resolves to the base class, not the calling class. PHP 8.0+ has \`: static\` for the correct clone-on-write pattern; PHP 7.4 workaround is \`@return static\` in docblock (honored by PHPStan/Psalm). Cheap follow-up ticket if we ever add static analysis. Zero runtime impact today.
2. **\`ComputedExpression\` now inherits \`withFormatter()\` publicly** — the ticket assumed all 3 concretes had it; \`ComputedExpression\` didn't. Extraction accidentally exposes it. Consistent with its constructor's \`?callable \$formatter\` param, no existing consumers, harmless. Note only.
3. **No test for \`ComputedExpression::withFormatter()\`** — coverage gap given the newly exposed method. Low priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)