### PR TITLE
fix(viewer): reserved-width scaler wrapper for zoom overflow (Ticket 007)

### DIFF
--- a/frontend/src/components/ReportCanvas.vue
+++ b/frontend/src/components/ReportCanvas.vue
@@ -8,13 +8,18 @@
             <div class="viewer-canvas__error-msg">{{ error }}</div>
             <button class="viewer-canvas__retry" @click="load" aria-label="Retry loading report">Retry</button>
         </div>
-        <main
+        <div
             v-else
-            class="report-inner"
-            :style="{ transform: `scale(${zoomLevel})`, transformOrigin: 'top center' }"
-            aria-label="Report content"
-            v-html="reportHtml"
-        ></main>
+            class="report-scaler"
+            :style="{ width: `${basePageWidth * zoomLevel}pt`, height: `${basePageHeight * zoomLevel}pt` }"
+        >
+            <main
+                class="report-inner"
+                :style="{ transform: `scale(${zoomLevel})`, transformOrigin: 'top left' }"
+                aria-label="Report content"
+                v-html="reportHtml"
+            ></main>
+        </div>
     </div>
 </template>
 
@@ -22,7 +27,29 @@
 import { ref, onMounted } from 'vue';
 import { zoomLevel, reportUrl, loading, error, empty } from '../state/viewerState';
 
-const reportHtml = ref<string>('');
+// US Letter default (612 x 792 pt) — matches PageConfig default on the server.
+const DEFAULT_PAGE_WIDTH  = 612;
+const DEFAULT_PAGE_HEIGHT = 792;
+
+const reportHtml     = ref<string>('');
+const basePageWidth  = ref<number>(DEFAULT_PAGE_WIDTH);
+const basePageHeight = ref<number>(DEFAULT_PAGE_HEIGHT);
+
+/**
+ * Parse a CSSStyleDeclaration length string like "612pt" or "792.00pt" to a
+ * number of points. Returns null if the value is missing or not in pt units,
+ * so callers can fall back to a default.
+ */
+function parsePtLength(value: string): number | null {
+    if (!value) {
+        return null;
+    }
+    const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)pt$/);
+    if (!match) {
+        return null;
+    }
+    return parseFloat(match[1]);
+}
 
 async function load(): Promise<void> {
     if (!reportUrl.value) {
@@ -55,6 +82,31 @@ async function load(): Promise<void> {
         const styleBlocks = Array.from(doc.head.querySelectorAll('style'))
             .map((s) => s.outerHTML)
             .join('\n');
+
+        // Extract base page dimensions from the first .fu-page element's inline
+        // style. HtmlRenderer::renderPage emits e.g. style="width:612.00pt;height:792.00pt;".
+        // These dimensions size the .report-scaler wrapper so the scroll
+        // container reserves the correct horizontal space at any zoom level
+        // (Ticket 007 — reserved-width wrapper approach).
+        const firstPage = doc.querySelector('.fu-page') as HTMLElement | null;
+        if (firstPage) {
+            const w = parsePtLength(firstPage.style.width);
+            const h = parsePtLength(firstPage.style.height);
+            basePageWidth.value  = w ?? DEFAULT_PAGE_WIDTH;
+            basePageHeight.value = h ?? DEFAULT_PAGE_HEIGHT;
+            if (w === null || h === null) {
+                console.warn(
+                    '[ReportCanvas] .fu-page found but width/height style unparsable; falling back to US Letter (612x792).'
+                );
+            }
+        } else {
+            basePageWidth.value  = DEFAULT_PAGE_WIDTH;
+            basePageHeight.value = DEFAULT_PAGE_HEIGHT;
+            console.warn(
+                '[ReportCanvas] No .fu-page element in report HTML; falling back to US Letter (612x792) for scaler dimensions.'
+            );
+        }
+
         reportHtml.value = styleBlocks + doc.body.innerHTML;
     } catch (e) {
         error.value = `Failed to load report: ${e instanceof Error ? e.message : String(e)}`;
@@ -75,6 +127,26 @@ onMounted(load);
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+/*
+ * Reserved-width wrapper (Ticket 007).
+ *
+ * The child .report-inner uses `transform: scale(zoomLevel)` from a top-left
+ * origin. Because CSS transforms don't affect layout size, we need this wrapper
+ * to reserve the post-scale footprint in the scroll container. Without it, at
+ * zoom > 100% the report visually overflows but the scroll container thinks
+ * the content is only its natural (unscaled) size — combined with
+ * `align-items: center` on .viewer-canvas the overflowing left edge became
+ * unreachable via horizontal scroll.
+ *
+ * Flex parent's align-items: center centers this wrapper when it's narrower
+ * than the viewport (zoom <= 100%), preserving the centered feel at the
+ * common case.
+ */
+.report-scaler {
+    position: relative;
+    flex-shrink: 0;
 }
 
 .viewer-canvas__state {
@@ -119,6 +191,17 @@ onMounted(load);
 @media print {
     .viewer-canvas__state {
         display: none !important;
+    }
+    /*
+     * In print, the scale transform is suppressed by the global @media print
+     * rule in App.vue (transform: none !important on .report-inner). The
+     * scaler wrapper still has explicit width/height inline, but browsers
+     * paginate on the actual report content and @page rules — collapse the
+     * wrapper so it can't create phantom whitespace or spurious page breaks.
+     */
+    .report-scaler {
+        width: auto !important;
+        height: auto !important;
     }
 }
 </style>


### PR DESCRIPTION
## Summary

Fixes the zoom overflow bug where the report's left edge became unreachable at zoom >100%. Uses the reserved-width wrapper approach the ticket approved (not the naive \`flex-start\` fix that was tried and reverted before).

**Structural change in \`ReportCanvas.vue\`:**

- Wraps \`<main class="report-inner">\` in a new \`<div class="report-scaler">\` whose explicit width/height track \`basePageWidth * zoomLevel\` and \`basePageHeight * zoomLevel\`. The scaler reserves horizontal space in the scroll container.
- Changes \`transform-origin\` from \`top center\` → \`top left\` on \`.report-inner\`.
- Keeps \`align-items: center\` on \`.viewer-canvas\` so at ≤100% zoom the report stays visually centered.
- Extracts \`basePageWidth\`/\`basePageHeight\` from the first \`.fu-page\` element's inline style at load time (the server already emits this — no server change needed). Falls back to US Letter (612 × 792) with a \`console.warn\` if \`.fu-page\` is missing.
- Added scoped \`@media print\` rule to collapse the scaler's inline width/height to \`auto !important\` so it can't produce phantom whitespace or spurious page breaks in print output.

**Print behavior:** the global \`@media print\` rule in \`App.vue\` already sets \`transform: none !important\` on \`.report-inner\`, so scaling is already stripped for print. The new scaler CSS just makes sure the wrapper doesn't interfere.

## ⚠️ Manual testing required before merge

Automated verification is not possible for a zoom/scroll visual bug. Please test in a browser:

For each zoom level in {50%, 75%, 100%, 125%, 150%, 175%, 200%}:

1. **Scroll reachability (core Ticket 007 check).** At 125%–200%, drag the horizontal scrollbar all the way left and confirm the report page's left edge (with its shadow/border) is fully visible. Repeat all the way right — the right edge should also be fully visible.
2. **Centering at ≤100%.** At 50%/75%/100%, confirm the report page is horizontally centered in the grey canvas, not left-aligned.
3. **Print at high zoom.** \`Cmd/Ctrl+P\` at 150% zoom — confirm print preview shows the report at 1:1 (not scaled up) with no phantom blank pages caused by the scaler wrapper.
4. **Fallback.** Point the viewer at a URL returning HTML without \`.fu-page\` (e.g. an error page) and confirm you see a \`[ReportCanvas] No .fu-page element ...\` console warning; the wrapper should size to 612×792 pt.

**Recommended test report:** any existing report that renders 2+ pages wide of content at 200% zoom is the strongest test.

## Automated checks

- [x] \`cd frontend && vue-tsc --noEmit\` — clean (types unchanged).
- [x] \`cd frontend && npm run build\` — succeeds.
- [ ] Manual browser test as above — **required from human reviewer**.

## Non-goals

- No server-side change to \`HtmlRenderer\` (the ticket mentioned a \`data-page-width\` attribute as an option, but the info is already emitted via inline style — this PR consumes it instead).
- No changes to \`ViewerToolbar\`, \`App.vue\`, or \`viewerState.ts\` — kept surgical to \`ReportCanvas.vue\`.
- No behavior change at ≤100% zoom (the case that was regressed by the previous naive fix attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)