### PR TITLE
fix(viewer): zoom +/- snap to nearest preset (Ticket 011 Option B)

### DIFF
--- a/frontend/src/state/viewerState.ts
+++ b/frontend/src/state/viewerState.ts
@@ -6,13 +6,28 @@ export const loading:   Ref<boolean>         = ref(false);
 export const error:     Ref<string | null>   = ref(null);
 export const empty:     Ref<boolean>         = ref(false);
 
-const ZOOM_STEP = 0.25;
-const ZOOM_MIN  = 0.5;
-const ZOOM_MAX  = 2.0;
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 2.0;
 
 export const ZOOM_PRESETS: number[] = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
 
-export function zoomIn():              void { zoomLevel.value = Math.min(ZOOM_MAX, +(zoomLevel.value + ZOOM_STEP).toFixed(2)); }
-export function zoomOut():             void { zoomLevel.value = Math.max(ZOOM_MIN, +(zoomLevel.value - ZOOM_STEP).toFixed(2)); }
+// Presets are the source of truth for +/- (Ticket 011 Option B): snap to
+// the next/previous preset rather than stepping by a fixed increment. Users
+// starting from an off-preset value (e.g. programmatic zoomTo) will still
+// land on a preset after one +/- press.
+export function zoomIn(): void {
+    const next = ZOOM_PRESETS.find((p) => p > zoomLevel.value);
+    zoomLevel.value = next ?? ZOOM_MAX;
+}
+
+export function zoomOut(): void {
+    let prev = ZOOM_MIN;
+    for (const p of ZOOM_PRESETS) {
+        if (p < zoomLevel.value) prev = p;
+        else break;
+    }
+    zoomLevel.value = prev;
+}
+
 export function zoomReset():           void { zoomLevel.value = 1.0; }
 export function zoomTo(level: number): void { zoomLevel.value = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, +level.toFixed(2))); }


### PR DESCRIPTION
## Summary

Option B from Ticket 011: \`+\` and \`−\` buttons snap to the next/previous zoom preset instead of stepping by a fixed 0.25 increment. Presets are now the source of truth.

**Change in \`frontend/src/state/viewerState.ts\` only:**

- \`zoomIn\` finds the smallest preset strictly greater than the current zoom (falls back to \`ZOOM_MAX\` if none).
- \`zoomOut\` finds the largest preset strictly less than the current zoom (falls back to \`ZOOM_MIN\` if none).
- \`ZOOM_STEP\` removed — no longer used anywhere.
- \`zoomReset\`, \`zoomTo\`, \`ZOOM_PRESETS\`, \`ZOOM_MIN\`/\`MAX\` unchanged.

## Subtle behavior note

Because \`ZOOM_STEP\` (0.25) happened to equal the gap between adjacent presets (0.25), users starting from any preset already advanced between presets by coincidence. The change:

- **Makes the invariant explicit** — future preset changes (e.g. adding 1.33x) won't silently break the step alignment.
- **Handles off-preset starting points** — if \`zoomTo(0.83)\` sets the level programmatically, one press of \`+\` now lands on \`1.0\` (the next preset above 0.83) instead of \`1.08\`.

## UI escape hatch preserved

\`ViewerToolbar.vue\`'s disabled placeholder \`<option>\` (\`{{ zoom }}%\` when off-preset) is intentionally kept. It's still useful when programmatic code or a future feature lands an off-preset value — the user can see they're off-preset before the next \`+\`/\`−\` snaps them back to grid.

## Test plan

- [x] \`cd frontend && vue-tsc --noEmit\` — clean (0 errors).
- [x] Grep for lingering \`ZOOM_STEP\` references — none in \`frontend/src/\`.
- [ ] Manual sanity: at 100%, click \`+\` five times → should hit 125, 150, 175, 200, 200 (clamp). Click \`−\` from 100% four times → 75, 50, 50, 50. Optional but reassuring.

## Non-goals

- No component-level changes (\`ViewerToolbar.vue\` untouched).
- No new tests (frontend has no test infra yet per Ticket 012 Section 6).
- No API surface change on \`zoomTo\` — it still allows arbitrary levels within \[0.5, 2.0].

🤖 Generated with [Claude Code](https://claude.com/claude-code)