### PR TITLE
docs(tickets): file 019 + 020 as PR #14 follow-ups

### DIFF
--- a/docs/tickets/019-viewer-zoom-recentering.md
+++ b/docs/tickets/019-viewer-zoom-recentering.md
@@ -1,0 +1,56 @@
+# TICKET-019: Viewer should re-center the report when zoom changes
+
+**Status:** Open
+**Priority:** Medium (UX — surfaced during manual test of PR #14 / Ticket 007)
+**Source:** manual test 2026-08-23 — reserved-width scaler wrapper landed in PR #14 fixes scroll reachability, but the report does not visually re-center when the user zooms in or out
+**Scope:** `frontend/src/components/ReportCanvas.vue`, possibly `frontend/src/state/viewerState.ts`
+
+## Problem
+
+After [PR #14](https://github.com/edgecase123/report-writer/pull/14) landed the reserved-width scaler wrapper (Ticket 007), the horizontal-scroll unreachability bug is fixed. But zoom-driven UX still feels wrong: when the user changes zoom level via `+` / `−` / `Reset` / preset select, the report's position within the viewport does not re-center around the previous focal point.
+
+Concrete symptoms observed:
+
+- At 150% zoom, scroll to the right edge. Click `−` (back to 125%). The scroll position is preserved in raw px, so the report jumps to a different visual anchor rather than staying centered on the previously-visible area.
+- At 100% zoom, click `+` a couple of times. The report grows outward from `top-left` (per the new `transform-origin`), so the visible content shifts unpredictably — the user's mental "current view" is lost.
+
+The user's expectation (a standard document-viewer convention): after any zoom change, the viewport should re-anchor around the previously-visible center point, OR at minimum the report should be visually re-centered horizontally in the canvas.
+
+## Design options
+
+**Option A — Re-center on every zoom change (simple).**
+
+After `zoomLevel` changes, imperatively reset `scrollLeft` / `scrollTop` on `.viewer-canvas` so the scaler is horizontally centered and vertically at top. The user always sees the top-center of the scaled report post-zoom.
+
+- Simplest to implement (one `watch(zoomLevel, ...)` on scroll reset).
+- Loses focal-point preservation — if the user was reading page 3 and zooms, they jump back to page 1.
+- Matches the ticket's minimal ask: "both zooming in and out should center the report."
+
+**Option B — Preserve focal point (nicer UX).**
+
+Before the zoom transform applies, capture the current center-of-viewport in report coordinates. After the transform, adjust `scrollLeft`/`scrollTop` so that same coordinate lands at the center again.
+
+- Matches the behavior of Preview / Acrobat / Chrome PDF viewer.
+- More work — needs `beforeUpdate` / `nextTick` hooks, coordinate math against the scaler's transformed origin.
+- Only worth the complexity if users routinely zoom while reading long reports.
+
+**Option C — Change `transform-origin` back to `top center` and rely on flexbox.**
+
+Would undo PR #14's fix and reintroduce the unreachable-overflow bug. Not viable — listed for completeness only.
+
+## Recommendation
+
+Start with **Option A**. It closes the immediate UX complaint from the manual test, is a one-line implementation, and doesn't foreclose Option B if we later want the focal-point-preserving behavior. Ship it as a small follow-up to PR #14.
+
+## Acceptance criteria
+
+- [ ] After any zoom change (via `+`, `−`, `Reset`, or preset select), the `.viewer-canvas` scroll position resets so the scaler is visually centered horizontally.
+- [ ] Vertical scroll position may reset to top-of-page or be preserved — pick one and document.
+- [ ] Manual test: at 100% zoom scrolled to the right edge, click `+` → report re-centers horizontally at 125%. Click `−` twice → same behavior back to 100% and 75%.
+- [ ] Print output unaffected.
+
+## Notes
+
+- The scaler wrapper approach from Ticket 007 means the scroll container's true content width matches `basePageWidth * zoomLevel`. Setting `scrollLeft = (scrollWidth - clientWidth) / 2` centers it horizontally regardless of zoom level.
+- Vue's `watch(zoomLevel, ...)` fires on any change source (buttons, select, external `zoomTo`). Wire the reset there.
+- If Option B is chosen later, this ticket can be closed and a new ticket filed for the focal-point-preserving logic.

--- a/docs/tickets/020-viewer-drag-to-pan-hand-cursor.md
+++ b/docs/tickets/020-viewer-drag-to-pan-hand-cursor.md
@@ -1,0 +1,62 @@
+# TICKET-020: Viewer needs drag-to-pan with hand-grab cursor when zoomed
+
+**Status:** Open
+**Priority:** Medium (UX — surfaced during manual test of PR #14 / Ticket 007)
+**Source:** manual test 2026-08-23 — reserved-width scaler wrapper landed in PR #14 makes the report scrollable at high zoom, but there is no non-scrollbar way to move it
+**Scope:** `frontend/src/components/ReportCanvas.vue`, possibly `frontend/src/state/viewerState.ts`
+
+## Problem
+
+After [PR #14](https://github.com/edgecase123/report-writer/pull/14) landed the reserved-width scaler wrapper (Ticket 007), users can scroll horizontally and vertically when the scaled report exceeds viewport size. But the only way to move the report is via the scrollbars — no drag-to-pan interaction.
+
+Standard document viewers (Preview, Adobe Acrobat, Figma, browser PDF viewer, image viewers) all support the same "hand tool" metaphor: hover over the content shows a grab cursor; mousedown-drag pans the viewport; release drops the position.
+
+Missing on the current viewer:
+
+- No `cursor: grab` when hovering over the report at any zoom level (or specifically when zoomed > viewport size).
+- No mousedown-drag interaction to translate the scroll position.
+- No visual affordance that the report is pannable at high zoom.
+
+## Design shape
+
+**Interaction:**
+
+- When the report content is larger than the viewport in EITHER axis (i.e. `.viewer-canvas` has horizontal or vertical overflow), set `cursor: grab` on the scroll container.
+- On `mousedown`, capture the initial mouse position + initial scroll position. Set `cursor: grabbing`.
+- On `mousemove` while dragging, update `scrollLeft` / `scrollTop` by the mouse delta.
+- On `mouseup` / `mouseleave`, release drag; restore `cursor: grab` (or `default` if content fits).
+
+**Modifier consideration:**
+
+- Some viewers make hand-pan the default (Acrobat with Hand Tool selected).
+- Some require spacebar-hold to activate (Photoshop, Figma).
+- Reports are read, not edited — default-on hand cursor is fine. No mode toggle needed.
+
+**Interaction with text selection:**
+
+- Text elements in reports are selectable (default browser behavior on the injected HTML). Drag-to-pan would collide with drag-to-select.
+- Options:
+  - (a) Hand-pan only when mousedown originates on non-text (background, page margin). Text selection still works if mousedown is on a text element.
+  - (b) Hand-pan always; text selection disabled on the report content (`user-select: none` on `.report-inner`).
+  - (c) Spacebar-hold gate — hand-pan only when spacebar is held, otherwise text selection is normal.
+- Preference: (a) — most natural. Users click on empty background to pan; click on text to select. Matches PDF viewer conventions.
+
+**Touch / mobile:**
+
+- Out of scope for now. Viewer is desktop-only per project design conventions (US Letter print orientation).
+- Touch pan via `touch-action: pan-x pan-y` works natively via scrollbars; drag-to-pan would need pointer-event handling. Defer.
+
+## Acceptance criteria
+
+- [ ] When the scroll container has horizontal or vertical overflow, the cursor over the report is `grab`.
+- [ ] Mousedown-drag on the report (originating on non-text) translates the scroll position by the drag delta.
+- [ ] Cursor changes to `grabbing` during active drag; back to `grab` on release.
+- [ ] Text selection on report elements still works when the mousedown originates on a text element.
+- [ ] Print output unaffected (cursor is a screen-only concern; no `@media print` change needed).
+- [ ] Manual test: at 200% zoom on a wide report, hover the background → grab cursor; drag left/right/up/down → report pans; drag on a text element → text selection (no pan).
+
+## Notes
+
+- The scaler-wrapper approach from Ticket 007 means the scroll container is `.viewer-canvas` and its `scrollLeft`/`scrollTop` are the levers to move. Drag delta translates directly to scroll delta.
+- Consider using a `useDragPan()` composable if this pattern ever appears elsewhere (unlikely in a report viewer, but the split-screen builder UI from Sub-project A might want it on the JSON preview).
+- Related follow-up: [Ticket 019](019-viewer-zoom-recentering.md) — different UX concern (zoom-driven re-centering), same file.

--- a/docs/tickets/README.md
+++ b/docs/tickets/README.md
@@ -26,6 +26,8 @@ Local ticket store — GitHub-issue-shaped so each file can be promoted to `edge
 | [016](016-extension-hooks-lifecycle-plus-immutability-retrofit.md) | Add lifecycle hooks to ReportBuilder + DefinitionFiller (immutable-fluent); retrofit `onBand` immutability | Medium | design session 2026-08-23 | ✅ Closed (2026-08-23) |
 | [017](017-title-alignment-vs-columns-vs-page.md) | Title element width — columns extent vs printable page width | Low | design 2026-08-23 | ✅ Closed (2026-08-23) |
 | [018](018-pageconfig-right-margin-and-printable-width.md) | PageConfig missing right margin and printableWidth() | Medium | design 2026-08-23 | ✅ Closed (2026-08-23) |
+| [019](019-viewer-zoom-recentering.md) | Viewer should re-center the report when zoom changes | Medium | manual test 2026-08-23 (PR #14 follow-up) | Open |
+| [020](020-viewer-drag-to-pan-hand-cursor.md) | Viewer needs drag-to-pan with hand-grab cursor when zoomed | Medium | manual test 2026-08-23 (PR #14 follow-up) | Open |
 
 ## Fixed in the same session (no tickets — reference commits)
 


### PR DESCRIPTION
## Summary

Two new tickets surfaced during the manual browser test of PR #14 (zoom overflow fix, now merged as \`42404ae\`):

- **Ticket 019** — Viewer should re-center the report when zoom changes. PR #14 fixes scroll reachability but doesn't re-anchor the viewport after zoom. Recommendation is Option A (simple re-center-on-zoom via a \`watch(zoomLevel, ...)\`); Option B (focal-point preservation) noted as later polish.
- **Ticket 020** — Viewer needs drag-to-pan with hand-grab cursor. Users can move the zoomed report via scrollbars but there's no standard hand-tool interaction. Design shape uses cursor: grab / grabbing + mousedown-drag delta → scrollLeft/scrollTop translation, gated on non-text mousedown so text selection still works.

Both are Medium priority (real UX gaps, not blockers). Both are self-contained frontend-only work.

## Test plan

- [x] Docs-only; no code changes; test suites unchanged.
- [x] Ledger updated to list both new tickets under Open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)