### PR TITLE
docs(specs+plans): A3 design + A3.1 implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-08-23-a3.1-schema-and-seed-extension.md
+++ b/docs/superpowers/plans/2026-08-23-a3.1-schema-and-seed-extension.md
@@ -1,0 +1,805 @@
+# A3.1 — Schema + Seed Extension Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `staff` and `payments` tables to the coffee-shop schema; extend the deterministic demo seed to populate them alongside existing tables; bootstrap the shared `writer-app/tests/Fixtures/coffee-shop-mini.sql` test fixture. Existing tables, row counts, and rendered output for Daily Sales remain byte-identical.
+
+**Architecture:** Additive schema + additive seed. Two new inserts (`insertStaff`, `insertPayments`) called from `Seed::run()` **after** `insertOrdersAndItems` — the payments seed reads back the closed orders it needs. `mt_srand(1)` stays at the top; new seed steps consume the same PRNG stream so any change to earlier steps would ripple, but adding steps after them doesn't perturb prior output. `SeedDeterminismTest` grows to cover the new tables. The `.sql` fixture is a hand-authored ~20-row snapshot separate from the demo seed.
+
+**Tech Stack:** PHP 7.4+, PDO-SQLite, PHPUnit 9.5. No frontend, no library changes, no HTTP changes.
+
+**Sub-project ticket:** [012 — Sub-project A](../../tickets/012-implement-standalone-runtime-subproject-a.md) — A3.1 of A3.
+**Design spec:** [2026-08-23-a3-sample-reports-design.md](../specs/2026-08-23-a3-sample-reports-design.md)
+
+**Related decisions:**
+- [ADR-002](../../09-conventions/decisions/002-sqlite-coffee-shop-toy-domain.md) — SQLite + coffee-shop domain, deterministic seed
+- [ADR-011](../../09-conventions/decisions/011-docs-after-implementation.md) — no doc pages for code that doesn't exist yet
+- [ADR-013](../../09-conventions/decisions/013-framework-agnostic-library.md) — `writer-app/` is dev/test/demo scaffolding
+
+**Prerequisites:**
+- A2 landed (verify `writer-app/database/schema.sql` exists and has the four existing tables)
+- Green suites on `main`:
+  - `cd writer && vendor/bin/phpunit` → `OK (163 tests, 300 assertions)`
+  - `cd writer-app && vendor/bin/phpunit` → `OK (30 tests, 61 assertions)`
+- Docker available for the Task 6 end-to-end check (`docker --version` prints anything)
+
+**Working directory:**
+- All PHP commands run from `/Users/leejenkins/dev/report-writer/writer-app/`.
+- Git commands run from `/Users/leejenkins/dev/report-writer/`.
+
+---
+
+## File Structure
+
+Everything new or modified is under `writer-app/`. Library (`writer/`) not touched.
+
+```
+writer-app/
+├── database/
+│   ├── schema.sql                                # MODIFY — add staff + payments tables and their indexes
+│   └── seed.php                                  # MODIFY — add insertStaff, insertPayments, call from run()
+└── tests/
+    ├── Fixtures/
+    │   └── coffee-shop-mini.sql                  # NEW — ~20-row deterministic fixture across all 6 tables
+    └── Unit/
+        └── Database/
+            ├── SeedDeterminismTest.php           # MODIFY — dump staff + payments in seedAndDump()
+            ├── SeedStaffTest.php                 # NEW — asserts seed populates staff table
+            ├── SeedPaymentsTest.php              # NEW — asserts seed populates payments matching closed orders
+            └── CoffeeShopMiniFixtureTest.php     # NEW — loads .sql fixture and asserts row counts + edge cases
+```
+
+**File responsibilities:**
+
+- `schema.sql` — CREATE TABLE statements only, no data, no framework tie-ins. Portable to any SQLite consumer.
+- `seed.php` — one class (`Seed`), pure static methods, transactional. Each `insertX` method owns its table.
+- `coffee-shop-mini.sql` — hand-authored SQL that any test can `$pdo->exec(file_get_contents(...))`. Kept small (~20 rows total) so tests boot fast; covers edge cases each downstream report needs.
+- Three new tests, one per new concern, so a failing test names its cause without spelunking.
+
+---
+
+## Task 0: Verify baseline
+
+- [ ] **Step 1: Confirm branch state**
+
+Run: `git -C /Users/leejenkins/dev/report-writer status`
+Expected: `On branch main`, working tree clean, in sync with `origin/main`.
+
+- [ ] **Step 2: Confirm schema state**
+
+Run: `grep -c "^CREATE TABLE" /Users/leejenkins/dev/report-writer/writer-app/database/schema.sql`
+Expected: `4` (categories, items, orders, order_items).
+
+- [ ] **Step 3: Confirm existing tests are green**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (30 tests, 61 assertions)`.
+
+- [ ] **Step 4: Cut a feature branch**
+
+Run: `git -C /Users/leejenkins/dev/report-writer checkout -b feat/a3.1-schema-and-seed-extension`
+Expected: `Switched to a new branch 'feat/a3.1-schema-and-seed-extension'`.
+
+---
+
+## Task 1: Extend schema with `staff` and `payments` tables
+
+**Files:**
+- Modify: `writer-app/database/schema.sql` (append after existing tables)
+
+- [ ] **Step 1: Append the new tables + indexes to `schema.sql`**
+
+Open `writer-app/database/schema.sql`. Under the existing `CREATE INDEX` lines, add:
+
+```sql
+
+CREATE TABLE IF NOT EXISTS staff (
+    id   INTEGER PRIMARY KEY,
+    name TEXT    NOT NULL,
+    role TEXT    NOT NULL              -- e.g. 'barista', 'shift_lead', 'manager'
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id            INTEGER PRIMARY KEY,
+    order_id      INTEGER NOT NULL REFERENCES orders(id),
+    method        TEXT    NOT NULL,    -- 'cash' | 'card' | 'mobile'
+    amount_cents  INTEGER NOT NULL,
+    taken_at      TEXT    NOT NULL,    -- ISO-8601 UTC
+    staff_id      INTEGER NOT NULL REFERENCES staff(id)
+);
+
+CREATE INDEX IF NOT EXISTS payments_order_id_idx ON payments(order_id);
+CREATE INDEX IF NOT EXISTS payments_taken_at_idx ON payments(taken_at);
+```
+
+Also replace the header comment at the top of the file:
+
+```sql
+-- Coffee-shop POS schema (subset used by A2).
+-- Full schema (staff, payments, template_drafts) lands with A3 and A5.
+```
+
+with:
+
+```sql
+-- Coffee-shop POS schema. staff + payments added in A3.1; template_drafts lands with A5.
+```
+
+- [ ] **Step 2: Verify schema still parses (no syntax errors)**
+
+Run:
+
+```bash
+cd /Users/leejenkins/dev/report-writer/writer-app && \
+php -r 'require "vendor/autoload.php"; \
+    $pdo = \ReportWriter\App\Database\SqliteConnectionFactory::createInMemoryWithSchema( \
+        __DIR__ . "/database/schema.sql"); \
+    foreach ($pdo->query("SELECT name FROM sqlite_master WHERE type=\"table\" ORDER BY name") as $r) { \
+        echo $r[0] . PHP_EOL; \
+    }'
+```
+
+Expected output (alphabetical, exactly 6 lines):
+```
+categories
+items
+order_items
+orders
+payments
+staff
+```
+
+- [ ] **Step 3: Confirm existing tests still pass**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (30 tests, 61 assertions)` — no test touches staff/payments yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/database/schema.sql
+git commit -m "feat(schema): add staff + payments tables (A3.1)"
+```
+
+---
+
+## Task 2: Seed the `staff` table (TDD)
+
+**Files:**
+- Create: `writer-app/tests/Unit/Database/SeedStaffTest.php`
+- Modify: `writer-app/database/seed.php` (add `insertStaff`, call it from `run()`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `writer-app/tests/Unit/Database/SeedStaffTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Database;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+
+final class SeedStaffTest extends TestCase
+{
+    public function testSeedPopulatesStaffTable(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+
+        require __DIR__ . '/../../../database/seed.php';
+        \ReportWriter\App\Database\Seed::run($pdo);
+
+        $rows = $pdo->query('SELECT id, name, role FROM staff ORDER BY id')->fetchAll(\PDO::FETCH_ASSOC);
+
+        // Six-person fixed roster: 4 baristas, 1 shift lead, 1 manager.
+        $this->assertCount(6, $rows);
+        $this->assertSame([1, 2, 3, 4, 5, 6], array_column($rows, 'id'));
+
+        $roleCounts = array_count_values(array_column($rows, 'role'));
+        $this->assertSame(4, $roleCounts['barista'] ?? 0);
+        $this->assertSame(1, $roleCounts['shift_lead'] ?? 0);
+        $this->assertSame(1, $roleCounts['manager'] ?? 0);
+
+        // Every staff row has a non-empty name.
+        foreach ($rows as $row) {
+            $this->assertNotEmpty($row['name'], 'staff.name must be non-empty');
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SeedStaffTest`
+Expected: `1) ...testSeedPopulatesStaffTable` fails with `Failed asserting that actual size 0 matches expected size 6.` (staff table exists but seed doesn't populate it yet).
+
+- [ ] **Step 3: Extend `seed.php` with `insertStaff`**
+
+In `writer-app/database/seed.php`, inside `Seed::run()`, insert a call to `self::insertStaff($pdo);` **immediately after** `self::insertItems($pdo);` and **before** `self::insertOrdersAndItems($pdo);` (staff is order-independent; insert it early so it stays deterministic even if we later re-order the orders step):
+
+```php
+        try {
+            self::wipe($pdo);
+            self::insertCategories($pdo);
+            self::insertItems($pdo);
+            self::insertStaff($pdo);                 // ← NEW
+            self::insertOrdersAndItems($pdo);
+            $pdo->commit();
+```
+
+Extend `wipe()` to clear `staff` and `payments` first (payments FKs staff; staff has no FK-in — but wiping in FK-dependency order is the safe habit). Update `wipe()` to:
+
+```php
+    private static function wipe(PDO $pdo): void
+    {
+        $pdo->exec('DELETE FROM payments');       // ← NEW (before order_items so FK order_id is stable)
+        $pdo->exec('DELETE FROM order_items');
+        $pdo->exec('DELETE FROM orders');
+        $pdo->exec('DELETE FROM items');
+        $pdo->exec('DELETE FROM staff');          // ← NEW (no FK-in from remaining tables)
+        $pdo->exec('DELETE FROM categories');
+    }
+```
+
+Add the `insertStaff` method (place it after `insertItems` for readability):
+
+```php
+    private static function insertStaff(PDO $pdo): void
+    {
+        // Fixed six-person roster. No PRNG use here so this method contributes
+        // zero draws to the mt_srand stream — safe to add/remove without
+        // rippling into later order/payment randomness.
+        $roster = [
+            [1, 'Ada Lovelace',    'barista'],
+            [2, 'Ben Carson',      'barista'],
+            [3, 'Cleo Diaz',       'barista'],
+            [4, 'Devon Ellis',     'barista'],
+            [5, 'Farah Grant',     'shift_lead'],
+            [6, 'Hiro Yamamoto',   'manager'],
+        ];
+        $stmt = $pdo->prepare('INSERT INTO staff (id, name, role) VALUES (:id, :name, :role)');
+        foreach ($roster as [$id, $name, $role]) {
+            $stmt->execute(['id' => $id, 'name' => $name, 'role' => $role]);
+        }
+    }
+```
+
+Also update the class-level docblock:
+
+```php
+/**
+ * Deterministic coffee-shop seed for the demo.
+ *
+ * Contract per ADR-002: mt_srand(1); ~90 days of activity ending on a fixed
+ * anchor date (2026-08-22 UTC). Populates categories, items, staff, orders,
+ * order_items, payments. A5 will add template_drafts.
+ */
+```
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SeedStaffTest`
+Expected: `OK (1 test, ...)`.
+
+- [ ] **Step 5: Confirm no regression in existing tests**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (32 tests, ...)` (30 pre-existing + new SeedStaffTest + one more coming; the pre-existing 30 must all still pass).
+
+Critically, `SeedDeterminismTest` should still pass **as-is** because we inserted staff *before* the orders/items step but staff's insertion uses no PRNG draws — so the order/item stream is byte-identical.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/database/seed.php writer-app/tests/Unit/Database/SeedStaffTest.php
+git commit -m "feat(seed): populate staff table (A3.1)"
+```
+
+---
+
+## Task 3: Seed the `payments` table (TDD)
+
+**Files:**
+- Create: `writer-app/tests/Unit/Database/SeedPaymentsTest.php`
+- Modify: `writer-app/database/seed.php` (add `insertPayments`, call from `run()`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `writer-app/tests/Unit/Database/SeedPaymentsTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Database;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+
+final class SeedPaymentsTest extends TestCase
+{
+    public function testEveryClosedOrderHasExactlyOnePayment(): void
+    {
+        $pdo = $this->seededPdo();
+
+        $closedOrders = (int) $pdo->query(
+            'SELECT COUNT(*) FROM orders WHERE closed_at IS NOT NULL'
+        )->fetchColumn();
+        $paymentCount = (int) $pdo->query('SELECT COUNT(*) FROM payments')->fetchColumn();
+
+        $this->assertGreaterThan(0, $closedOrders, 'seed should have at least one closed order');
+        $this->assertSame(
+            $closedOrders,
+            $paymentCount,
+            'payments must be 1:1 with closed orders (A3.1 v1: single payment per order)'
+        );
+    }
+
+    public function testPaymentAmountsMatchOrderTotals(): void
+    {
+        $pdo = $this->seededPdo();
+
+        $mismatches = $pdo->query(
+            "SELECT p.order_id
+               FROM payments p
+               JOIN (
+                   SELECT order_id, SUM(quantity * unit_price_cents) AS total_cents
+                     FROM order_items
+                    GROUP BY order_id
+               ) t ON t.order_id = p.order_id
+              WHERE p.amount_cents != t.total_cents"
+        )->fetchAll();
+
+        $this->assertSame([], $mismatches, 'each payment.amount_cents must equal SUM(order_items) for that order');
+    }
+
+    public function testPaymentMethodsAreLimitedToTheThreeAllowed(): void
+    {
+        $pdo = $this->seededPdo();
+
+        $methods = $pdo->query('SELECT DISTINCT method FROM payments')->fetchAll(\PDO::FETCH_COLUMN);
+        sort($methods);
+        $this->assertSame(['card', 'cash', 'mobile'], $methods);
+    }
+
+    public function testStaffIdIsAValidStaffRow(): void
+    {
+        $pdo = $this->seededPdo();
+
+        $orphans = (int) $pdo->query(
+            'SELECT COUNT(*) FROM payments WHERE staff_id NOT IN (SELECT id FROM staff)'
+        )->fetchColumn();
+
+        $this->assertSame(0, $orphans);
+    }
+
+    private function seededPdo(): \PDO
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+        require __DIR__ . '/../../../database/seed.php';
+        \ReportWriter\App\Database\Seed::run($pdo);
+        return $pdo;
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SeedPaymentsTest`
+Expected: multiple failures — payments table has zero rows.
+
+- [ ] **Step 3: Extend `seed.php` with `insertPayments`**
+
+In `Seed::run()`, add the call **after** `insertOrdersAndItems`:
+
+```php
+        try {
+            self::wipe($pdo);
+            self::insertCategories($pdo);
+            self::insertItems($pdo);
+            self::insertStaff($pdo);
+            self::insertOrdersAndItems($pdo);
+            self::insertPayments($pdo);                 // ← NEW
+            $pdo->commit();
+```
+
+Add the method:
+
+```php
+    private static function insertPayments(PDO $pdo): void
+    {
+        // One payment per closed order. Amount = SUM(order_items) for that order.
+        // Method distribution ~55% card, ~30% cash, ~15% mobile (small integer
+        // buckets so the PRNG remains stable). Staff picked round-robin from
+        // baristas (ids 1-4) — determined by ordinal position, not PRNG, so this
+        // step uses zero draws for staff selection.
+        $rows = $pdo->query(
+            "SELECT o.id AS order_id, o.closed_at,
+                    COALESCE(SUM(oi.quantity * oi.unit_price_cents), 0) AS total_cents
+               FROM orders o
+          LEFT JOIN order_items oi ON oi.order_id = o.id
+              WHERE o.closed_at IS NOT NULL
+           GROUP BY o.id
+           ORDER BY o.id"
+        )->fetchAll(\PDO::FETCH_ASSOC);
+
+        $paymentStmt = $pdo->prepare(
+            'INSERT INTO payments (order_id, method, amount_cents, taken_at, staff_id)
+             VALUES (:oid, :method, :amount, :taken, :staff)'
+        );
+
+        $baristaIds = [1, 2, 3, 4];
+        $ordinal    = 0;
+        foreach ($rows as $r) {
+            $roll   = mt_rand(1, 100);
+            $method = $roll <= 55 ? 'card' : ($roll <= 85 ? 'cash' : 'mobile');
+            // Payment taken at order close time.
+            $staff  = $baristaIds[$ordinal % 4];
+            $paymentStmt->execute([
+                'oid'    => (int) $r['order_id'],
+                'method' => $method,
+                'amount' => (int) $r['total_cents'],
+                'taken'  => (string) $r['closed_at'],
+                'staff'  => $staff,
+            ]);
+            $ordinal++;
+        }
+    }
+```
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SeedPaymentsTest`
+Expected: `OK (4 tests, ...)`.
+
+- [ ] **Step 5: Confirm no regression**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (35 tests, ...)`. `SeedDeterminismTest` still passes — it seeds twice and diffs by table dump; payments are drawn from a deterministic stream so both runs match.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/database/seed.php writer-app/tests/Unit/Database/SeedPaymentsTest.php
+git commit -m "feat(seed): populate payments 1:1 with closed orders (A3.1)"
+```
+
+---
+
+## Task 4: Extend `SeedDeterminismTest` to cover new tables
+
+**Files:**
+- Modify: `writer-app/tests/Unit/Database/SeedDeterminismTest.php`
+
+- [ ] **Step 1: Extend `seedAndDump()` to include staff + payments**
+
+Edit `SeedDeterminismTest::seedAndDump()`. Add two new keys to the returned array (preserve order — keys are inserted lexicographically for readability):
+
+```php
+        return [
+            'categories'  => $pdo->query('SELECT * FROM categories  ORDER BY id')->fetchAll(),
+            'items'       => $pdo->query('SELECT * FROM items       ORDER BY id')->fetchAll(),
+            'orders'      => $pdo->query('SELECT * FROM orders      ORDER BY id')->fetchAll(),
+            'order_items' => $pdo->query('SELECT * FROM order_items ORDER BY id')->fetchAll(),
+            'payments'    => $pdo->query('SELECT * FROM payments    ORDER BY id')->fetchAll(),
+            'staff'       => $pdo->query('SELECT * FROM staff       ORDER BY id')->fetchAll(),
+        ];
+```
+
+- [ ] **Step 2: Run the determinism test**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SeedDeterminismTest`
+Expected: `OK (1 test, 1 assertion)`. Both runs must produce identical dumps for every table including the two new ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/tests/Unit/Database/SeedDeterminismTest.php
+git commit -m "test(seed): assert determinism across staff + payments (A3.1)"
+```
+
+---
+
+## Task 5: Bootstrap `coffee-shop-mini.sql` fixture
+
+**Files:**
+- Create: `writer-app/tests/Fixtures/coffee-shop-mini.sql`
+- Create: `writer-app/tests/Unit/Database/CoffeeShopMiniFixtureTest.php`
+
+This is a small hand-authored dataset that A3.2+ snapshot tests will load. Distinct from `Support/DailySalesFixture.php` (which A6 will retire per its own docblock) — this file is portable to any consumer and hand-tuned to exercise each report's edge cases.
+
+- [ ] **Step 1: Create the `.sql` file**
+
+Create `writer-app/tests/Fixtures/coffee-shop-mini.sql`:
+
+```sql
+-- coffee-shop-mini.sql
+--
+-- Deterministic ~20-row fixture shared across A3 snapshot tests.
+-- Anchor date: 2026-08-22 (same as Seed::ANCHOR_DATE).
+--
+-- Edge cases included:
+--   • Sales by Category: multiple categories with different totals
+--   • Open Tabs: order 2000 has closed_at IS NULL
+--   • Sales by Category → Item: multiple items per category, multiple orders per item
+--   • Register Close: two payment methods (cash + card) on 2026-08-22
+--   • Full Menu Book: category has a non-null description column (added in later task if needed)
+
+DELETE FROM payments;
+DELETE FROM order_items;
+DELETE FROM orders;
+DELETE FROM items;
+DELETE FROM staff;
+DELETE FROM categories;
+
+INSERT INTO categories (id, name) VALUES
+    (1, 'Coffee'),
+    (2, 'Pastry');
+
+INSERT INTO items (id, category_id, name, unit_price_cents) VALUES
+    (1, 1, 'Espresso',  500),
+    (2, 1, 'Latte',     600),
+    (3, 2, 'Croissant', 400),
+    (4, 2, 'Muffin',    350);
+
+INSERT INTO staff (id, name, role) VALUES
+    (1, 'Ada Lovelace', 'barista'),
+    (2, 'Farah Grant',  'shift_lead');
+
+-- 2026-08-22 orders (all closed).
+INSERT INTO orders (id, opened_at, closed_at) VALUES
+    (1001, '2026-08-22T09:10:00Z', '2026-08-22T09:15:00Z'),
+    (1002, '2026-08-22T10:20:00Z', '2026-08-22T10:22:00Z'),
+    (1003, '2026-08-22T14:00:00Z', '2026-08-22T14:05:00Z');
+
+INSERT INTO order_items (id, order_id, item_id, quantity, unit_price_cents) VALUES
+    (1, 1001, 1, 1, 500),   -- 500  → order 1001
+    (2, 1001, 3, 1, 400),   -- 400  → order 1001 total 900
+    (3, 1002, 2, 2, 600),   -- 1200 → order 1002 total 1200
+    (4, 1003, 1, 1, 500),   -- 500  → order 1003
+    (5, 1003, 4, 1, 350);   -- 350  → order 1003 total 850
+
+INSERT INTO payments (id, order_id, method, amount_cents, taken_at, staff_id) VALUES
+    (1, 1001, 'card', 900,  '2026-08-22T09:15:00Z', 1),
+    (2, 1002, 'cash', 1200, '2026-08-22T10:22:00Z', 1),
+    (3, 1003, 'card', 850,  '2026-08-22T14:05:00Z', 2);
+
+-- Prior-day order (should be excluded by any date=2026-08-22 filter).
+INSERT INTO orders     (id, opened_at, closed_at)                                  VALUES (999, '2026-08-21T09:00:00Z', '2026-08-21T09:10:00Z');
+INSERT INTO order_items(id, order_id, item_id, quantity, unit_price_cents)         VALUES (99, 999, 2, 1, 600);
+INSERT INTO payments   (id, order_id, method, amount_cents, taken_at, staff_id)    VALUES (99, 999, 'cash', 600, '2026-08-21T09:10:00Z', 1);
+
+-- Open tab (closed_at NULL, no payment) — required by Open Tabs report.
+INSERT INTO orders     (id, opened_at, closed_at)                                  VALUES (2000, '2026-08-22T15:00:00Z', NULL);
+INSERT INTO order_items(id, order_id, item_id, quantity, unit_price_cents)         VALUES (200, 2000, 1, 1, 500);
+```
+
+- [ ] **Step 2: Write a test that loads and validates the fixture**
+
+Create `writer-app/tests/Unit/Database/CoffeeShopMiniFixtureTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Database;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+
+final class CoffeeShopMiniFixtureTest extends TestCase
+{
+    private const FIXTURE_PATH = __DIR__ . '/../../Fixtures/coffee-shop-mini.sql';
+
+    public function testFixtureLoadsIntoFreshSchemaAndHasExpectedRowCounts(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+        $pdo->exec((string) file_get_contents(self::FIXTURE_PATH));
+
+        $this->assertSame(2, $this->count($pdo, 'categories'));
+        $this->assertSame(4, $this->count($pdo, 'items'));
+        $this->assertSame(2, $this->count($pdo, 'staff'));
+        $this->assertSame(5, $this->count($pdo, 'orders'));       // 3 target-day + 1 prior + 1 open
+        $this->assertSame(8, $this->count($pdo, 'order_items'));  // 5 + 1 + 1 + 1 open
+        $this->assertSame(4, $this->count($pdo, 'payments'));     // 3 target-day + 1 prior; open tab has none
+    }
+
+    public function testFixtureIncludesOneOpenTab(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+        $pdo->exec((string) file_get_contents(self::FIXTURE_PATH));
+
+        $openCount = (int) $pdo->query('SELECT COUNT(*) FROM orders WHERE closed_at IS NULL')->fetchColumn();
+        $this->assertSame(1, $openCount, 'Open Tabs report needs at least one closed_at IS NULL row');
+    }
+
+    public function testFixturePaymentAmountsMatchOrderTotals(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+        $pdo->exec((string) file_get_contents(self::FIXTURE_PATH));
+
+        $mismatches = $pdo->query(
+            "SELECT p.order_id
+               FROM payments p
+               JOIN (
+                   SELECT order_id, SUM(quantity * unit_price_cents) AS total_cents
+                     FROM order_items
+                    GROUP BY order_id
+               ) t ON t.order_id = p.order_id
+              WHERE p.amount_cents != t.total_cents"
+        )->fetchAll();
+        $this->assertSame([], $mismatches, 'each hand-authored payment.amount_cents must match SUM(order_items)');
+    }
+
+    private function count(\PDO $pdo, string $table): int
+    {
+        return (int) $pdo->query("SELECT COUNT(*) FROM {$table}")->fetchColumn();
+    }
+}
+```
+
+- [ ] **Step 3: Run the fixture test**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter CoffeeShopMiniFixtureTest`
+Expected: `OK (3 tests, ...)`.
+
+- [ ] **Step 4: Confirm the whole app suite is green**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (38 tests, ...)` (30 baseline + `SeedStaffTest` 1 + `SeedPaymentsTest` 4 + `CoffeeShopMiniFixtureTest` 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/tests/Fixtures/coffee-shop-mini.sql writer-app/tests/Unit/Database/CoffeeShopMiniFixtureTest.php
+git commit -m "test(fixtures): bootstrap coffee-shop-mini.sql for A3 snapshot tests"
+```
+
+---
+
+## Task 6: End-to-end verification + push + PR
+
+- [ ] **Step 1: Verify library suite unaffected**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer && vendor/bin/phpunit`
+Expected: `OK (163 tests, 300 assertions)` — unchanged from baseline.
+
+- [ ] **Step 2: Run the demo container against the extended seed**
+
+Run:
+```bash
+cd /Users/leejenkins/dev/report-writer && ./scripts/demo-up
+```
+
+`demo-up` (default: `--reseed`) will re-run the seed inside the container. Watch for a successful "Demo is up" banner. If the seed throws an FK error, the wipe order in `Seed::wipe()` is wrong — fix and re-run.
+
+- [ ] **Step 3: Verify staff + payments actually populated in the demo DB**
+
+Run:
+```bash
+docker exec report-writer-php sqlite3 /app/writer-app/data/coffee-shop.sqlite \
+    "SELECT (SELECT COUNT(*) FROM staff) AS staff, (SELECT COUNT(*) FROM payments) AS payments"
+```
+
+Expected format: `6|<N>` where `<N>` is the number of closed orders in the seeded dataset (roughly 90 days × 8–24 orders/day, minus any open tabs — expect a four-digit number).
+
+- [ ] **Step 4: Verify orders + order_items are byte-identical to pre-A3.1**
+
+Daily Sales reads only `orders` + `order_items`, so any behavior change would show up as a diff in those rows. Since we added `insertStaff` *before* `insertOrdersAndItems` (staff uses zero PRNG draws) and `insertPayments` *after* it, the PRNG stream consumed by orders/items must be unchanged. Verify with a snapshot diff.
+
+Capture the current branch's snapshot:
+
+```bash
+docker exec report-writer-php sqlite3 /app/writer-app/data/coffee-shop.sqlite \
+    "SELECT id, opened_at, closed_at FROM orders ORDER BY id;
+     SELECT id, order_id, item_id, quantity, unit_price_cents FROM order_items ORDER BY id;" \
+    > /tmp/a3.1-orders.txt
+```
+
+Capture main's snapshot in an isolated worktree (safer than mutating the current one):
+
+```bash
+git -C /Users/leejenkins/dev/report-writer worktree add /tmp/rw-main main && \
+cd /tmp/rw-main && ./scripts/demo-up --reseed >/dev/null && \
+docker exec report-writer-php sqlite3 /app/writer-app/data/coffee-shop.sqlite \
+    "SELECT id, opened_at, closed_at FROM orders ORDER BY id;
+     SELECT id, order_id, item_id, quantity, unit_price_cents FROM order_items ORDER BY id;" \
+    > /tmp/main-orders.txt && \
+git -C /Users/leejenkins/dev/report-writer worktree remove /tmp/rw-main --force
+```
+
+*(The main-worktree step reuses the same container name `report-writer-php`; the reseed will overwrite the DB. That's fine — restore the branch's DB by running `./scripts/demo-up --reseed` from the branch again afterward.)*
+
+Diff:
+
+```bash
+diff /tmp/a3.1-orders.txt /tmp/main-orders.txt
+```
+
+Expected: zero output. If diff is non-empty, the `mt_rand` stream shifted — the fix is in `insertStaff` (if you accidentally introduced a PRNG call there) or a reordering of `Seed::run()` calls.
+
+Restore the branch's demo DB:
+
+```bash
+cd /Users/leejenkins/dev/report-writer && ./scripts/demo-up --reseed >/dev/null
+```
+
+- [ ] **Step 5: Push the branch and open the PR**
+
+```bash
+git -C /Users/leejenkins/dev/report-writer push -u origin feat/a3.1-schema-and-seed-extension
+
+gh pr create --repo edgecase123/report-writer \
+  --title "feat(A3.1): schema + seed extension — staff, payments, coffee-shop-mini.sql" \
+  --body "$(cat <<'EOF'
+## Summary
+- **Schema:** add \`staff (id, name, role)\` and \`payments (id, order_id, method, amount_cents, taken_at, staff_id)\` tables with supporting indexes. Existing tables unchanged.
+- **Seed:** \`Seed::run()\` now populates staff (fixed six-person roster, no PRNG draws) and payments (1:1 with closed orders, deterministic method mix). \`Seed::wipe()\` extended in FK-safe order.
+- **Fixtures:** bootstrap \`writer-app/tests/Fixtures/coffee-shop-mini.sql\` — a ~20-row hand-authored dataset covering all six tables + the edge cases A3.2–A3.6 need (multi-category totals, at least one open tab, prior-day exclusion row, per-method payment mix).
+- **Tests:** new \`SeedStaffTest\`, \`SeedPaymentsTest\` (4 assertions on the 1:1 + method + FK invariants), \`CoffeeShopMiniFixtureTest\`. \`SeedDeterminismTest\` extended to dump the two new tables.
+
+Daily Sales HTML output is byte-identical to \`main\` (verified via diff in Task 6 § 4).
+
+Design: [A3 spec](../docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md) § A3.1.
+Plan: [A3.1 plan](../docs/superpowers/plans/2026-08-23-a3.1-schema-and-seed-extension.md).
+
+## Test plan
+- [x] \`cd writer && vendor/bin/phpunit\` → \`OK (163 tests, 300 assertions)\` — unchanged
+- [x] \`cd writer-app && vendor/bin/phpunit\` → \`OK (38 tests, …)\` (30 baseline + 8 new)
+- [x] \`./scripts/demo-up\` succeeds; \`sqlite3\` count of staff = 6, payments = (# closed orders)
+- [x] Byte-identical Daily Sales output vs \`main\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Tear down or leave the demo running**
+
+If you're moving on to A3.2 in the same session, leave the container up:
+```bash
+docker ps --filter name=report-writer-php
+```
+
+Otherwise:
+```bash
+cd /Users/leejenkins/dev/report-writer && docker compose down
+```
+
+---
+
+## Rollback plan
+
+If A3.1 breaks Daily Sales output (Task 6 Step 4 diff is non-empty) and the fix isn't obvious:
+
+1. `git reset --hard main` on the feature branch to discard.
+2. Reopen the plan and reconsider Task 3 — the root cause is almost certainly that `insertPayments` shifts the `mt_rand` stream. Options:
+   - Move `insertPayments` to use `mt_srand(N)` with a *separate* seed at method start, resetting to preserve the parent stream. Trade-off: violates "one PRNG stream" simplicity.
+   - Accept a controlled Daily Sales re-baseline. If chosen, regenerate the Daily Sales snapshot in `writer-app/tests/Snapshots/` (if it exists — otherwise mention the visual re-review in the PR).
+3. Re-run Task 6 Step 4 diff after the fix.
+
+## Self-review checklist (executed 2026-08-23 when this plan was written)
+
+- **Spec coverage:** A3.1's row in the spec table (`staff, payments tables; staff-per-order + payments-per-closed-order in seed; SeedDeterminismTest still green`) maps to Tasks 1, 2, 3, 4. The spec's Testing section requirement for `coffee-shop-mini.sql` maps to Task 5.
+- **Placeholder scan:** none.
+- **Type/name consistency:** `Seed::insertStaff` and `Seed::insertPayments` used consistently across Task 2, 3, and rollback plan. Table names `staff`, `payments` consistent everywhere. Test class names `SeedStaffTest`, `SeedPaymentsTest`, `CoffeeShopMiniFixtureTest` consistent between File Structure, task headers, and commit commands.

--- a/docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md
+++ b/docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md
@@ -1,0 +1,102 @@
+# A3 — Five Sample Reports + Coffee-shop Seed Extension
+
+**Status:** Approved design, ready for implementation plan
+**Date:** 2026-08-23
+**Ticket:** [012 — Sub-project A epic](../../tickets/012-implement-standalone-runtime-subproject-a.md) (section 2)
+**Scope:** `writer-app/database/`, `writer-app/src/Reports/`, `writer-app/tests/`, one JSON template repository directory (path chosen in A3.2)
+
+## Context
+
+Ticket 012 § 2 approved 2026-08-22 lists six sample reports for Sub-project A. Daily Sales shipped in A2. This spec covers **A3 = the remaining five**, plus the schema and seed extensions required to feed them, sequenced into six sub-tickets.
+
+The epic-level *what* is not re-litigated here. This spec captures only the sequencing decisions, per-report specifics, and testing shape that the implementation plan needs.
+
+## Sub-ticket sequence
+
+Ordered simple → complex so each ticket lands on top of a green predecessor.
+
+| # | Sub-ticket | Deliverable | Depends on |
+|---|-----------|-------------|-----------|
+| **A3.1** | Schema + seed extension | `staff`, `payments` tables; staff-per-order + payments-per-closed-order in seed; `SeedDeterminismTest` still green | — |
+| **A3.2** | Sales by Category | `DefinitionFiller` JSON, one-level grouping, sum aggregate; establishes the JSON template repository location and loading pattern | — (uses existing tables) |
+| **A3.3** | Open Tabs | `DefinitionFiller` JSON, filter (`closed_at IS NULL`), no grouping; second JSON report to confirm the A3.2 pattern generalizes | A3.2 (template loader) |
+| **A3.4** | Sales by Category → Item | `ReportBuilder`, two-level nested groups (category → item); first `ReportBuilder`-based sample in A3 | — |
+| **A3.5** | Register Close | `DefinitionFiller` JSON, multi data-source (`orders` + `payments`), split-by-payment-method summary | A3.1 (payments seed), A3.3 |
+| **A3.6** | Full Menu Book — kitchen sink | Custom `ReportFillerInterface`; subreports (per category); splittable text (long descriptions); `ComputedExpression`; `onBand` hook | A3.1 (if descriptions are added there) or self-contained |
+
+## Per-report notes
+
+### A3.1 — Schema + seed
+
+- `staff (id, name, role)` — small fixed set (~6 rows: baristas, shift leads, manager).
+- `payments (id, order_id, method, amount_cents, taken_at, staff_id)` — one row per closed order (all-cash is fine for v1; add `card`, `mobile` for method-mix in A3.5).
+- Seed extension is additive: existing tables and existing row counts stay identical. New tables get populated in the same deterministic pass.
+- `SeedDeterminismTest` verifies byte-identical seed across two runs — extend to cover new tables.
+
+### A3.2 — Sales by Category (JSON)
+
+- **JSON template location:** `writer-app/templates/sales-by-category.json` (this ticket picks the directory).
+- **TemplateLoader wiring:** `writer-app/src/Reports/JsonTemplateRepository.php` — a thin adapter that reads a directory of `.json` files and hands them to `ReportWriter\Template\TemplateLoader` on demand. Registered in `Container.php`.
+- **Data source:** `SqliteSalesByCategoryProvider` — one row per category with `category_name, total_cents`, ordered by `total_cents DESC`.
+- **Report:** columns `Category | Total`; footer sum on `Total`.
+
+### A3.3 — Open Tabs (JSON)
+
+- Uses the JsonTemplateRepository from A3.2.
+- **Data source:** `SqliteOpenTabsProvider` — one row per `orders` row where `closed_at IS NULL`, with `order_id, opened_at, running_total_cents`.
+- **Report:** columns `Order | Opened | Running Total`; no grouping; no footer aggregate.
+- **Param:** none (or optional `as_of` timestamp; keep to none for simplicity).
+
+### A3.4 — Sales by Category → Item (ReportBuilder)
+
+- **Filler:** `SalesByCategoryItemFiller implements ReportFillerInterface`, using `ReportBuilder::groupBy(...)->groupBy(...)` internally.
+- **Data source:** `SqliteSalesByCategoryItemProvider` — one row per `(category_id, item_id)` with `category_name, item_name, quantity_sold, total_cents`.
+- **Report:** two-level groups; per-item detail line; per-category subtotal; grand total footer.
+- **Rationale for ReportBuilder:** DefinitionFiller supports only one grouping level (CLAUDE.md § "Two fillers, same output"), so any report that needs nested groups must use ReportBuilder.
+
+### A3.5 — Register Close (multi data-source JSON)
+
+- Uses JsonTemplateRepository. Two named data sources in the template:
+  - `orders` — closed orders on `params.date`
+  - `payments` — payments taken on `params.date`
+- **Providers:** `SqliteClosedOrdersProvider` and `SqliteDailyPaymentsProvider` (or reuse existing `SqliteDailySalesProvider` if the row shape suffices).
+- **Report layout:** header "Register Close — {date} — {staff_name}"; orders detail block; payment-method summary block (cash / card / mobile subtotals) using `AggregateExpression`.
+- **Param:** `date` (required), `staff_id` (optional; if provided, filter both data sources).
+
+### A3.6 — Full Menu Book (kitchen sink)
+
+- **Filler:** custom `MenuBookFiller implements ReportFillerInterface` — hand-rolled, does not use `ReportBuilder` shortcuts.
+- **Features exercised (must hit all — that's the point):**
+  - `SubreportContent` per category — outer report iterates categories, each category renders an inline subreport of its items.
+  - Splittable text — a per-category description paragraph that can wrap across a page boundary.
+  - `ComputedExpression` — e.g. a "margin %" cell computed from `unit_price_cents` and a fake COGS constant.
+  - `onBand` hook — post-build tweak (e.g. suppress the category-header band for categories with zero items).
+- **Data source:** `SqliteMenuBookProvider` — categories with items nested (either a single ragged fetch, or two providers wired together — implementer's call).
+- **Schema addition:** `categories.description TEXT` (may push to A3.1 or accept a small trailing schema tweak in A3.6 itself).
+
+## Registry & routing
+
+Each sub-ticket that lands a report also lands:
+
+- One `ReportDefinition` entry in `ReportRegistry` (id, label, filler class, param specs).
+- Wiring in `Container.php` for its provider(s).
+- The report is reachable at `/api/reports/{id}` via the existing `ReportController` — no controller changes.
+
+## Testing
+
+Follows ticket 012 § 6 pattern (no re-litigation):
+
+- **Snapshot test per report** against `writer-app/tests/Fixtures/coffee-shop-mini.sql`. Assertion form: `render($filler, $params) === expected_html`. Snapshots live at `writer-app/tests/Snapshots/{report-id}.html`.
+- Extend `coffee-shop-mini.sql` in A3.1 to cover new tables with a handful of deterministic rows (enough that each report has non-empty output and exercises its edge cases — e.g. Open Tabs needs at least one row with `closed_at IS NULL`).
+- No new Slim smoke tests unless routing changes (it shouldn't).
+
+## Out of scope for A3
+
+- `template_drafts` table + `/api/drafts` CRUD — belongs to A5.
+- Any frontend work (Builder UI, JSON editor, autocomplete) — that's A4/A5.
+- Handoff docs (`docs/handoff/adoption.md`) — deferred per ADR-011 (docs after implementation).
+- Additional payment methods beyond cash/card/mobile — keep the taxonomy small.
+
+## Open questions
+
+None load-bearing; implementer's-choice moments called out inline (e.g. JsonTemplateRepository directory name, whether A3.6's category description column joins A3.1 or comes with A3.6).


### PR DESCRIPTION
## Summary
Two docs added, no code touched:

- **Spec** — `docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md` — the A3-specific sequencing built on top of Ticket 012 §2. Six sub-tickets ordered simple → complex: A3.1 schema/seed, A3.2 Sales by Category, A3.3 Open Tabs, A3.4 Sales by Category → Item, A3.5 Register Close, A3.6 Full Menu Book.
- **Plan** — `docs/superpowers/plans/2026-08-23-a3.1-schema-and-seed-extension.md` — bite-sized TDD plan for A3.1 (staff + payments schema, seed extension, SeedDeterminismTest coverage, coffee-shop-mini.sql bootstrap). Task 6 verifies orders/order_items are byte-identical to main via a snapshot diff from an isolated git worktree.

Plans for A3.2–A3.6 will be drafted individually as we reach each sub-ticket.

## Test plan
- [x] Spec self-review — clean
- [x] Plan self-review — clean
- [ ] User review of both docs before A3.1 code plan runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)