### PR TITLE
feat(A3.1): schema + seed extension — staff, payments, coffee-shop-mini.sql

### DIFF
--- a/writer-app/database/schema.sql
+++ b/writer-app/database/schema.sql
@@ -1,5 +1,4 @@
--- Coffee-shop POS schema (subset used by A2).
--- Full schema (staff, payments, template_drafts) lands with A3 and A5.
+-- Coffee-shop POS schema. staff + payments added in A3.1; template_drafts lands with A5.
 
 CREATE TABLE IF NOT EXISTS categories (
     id   INTEGER PRIMARY KEY,
@@ -29,3 +28,21 @@ CREATE TABLE IF NOT EXISTS order_items (
 
 CREATE INDEX IF NOT EXISTS orders_closed_at_idx     ON orders(closed_at);
 CREATE INDEX IF NOT EXISTS order_items_order_id_idx ON order_items(order_id);
+
+CREATE TABLE IF NOT EXISTS staff (
+    id   INTEGER PRIMARY KEY,
+    name TEXT    NOT NULL,
+    role TEXT    NOT NULL              -- e.g. 'barista', 'shift_lead', 'manager'
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id            INTEGER PRIMARY KEY,
+    order_id      INTEGER NOT NULL REFERENCES orders(id),
+    method        TEXT    NOT NULL,    -- 'cash' | 'card' | 'mobile'
+    amount_cents  INTEGER NOT NULL,
+    taken_at      TEXT    NOT NULL,    -- ISO-8601 UTC
+    staff_id      INTEGER NOT NULL REFERENCES staff(id)
+);
+
+CREATE INDEX IF NOT EXISTS payments_order_id_idx ON payments(order_id);
+CREATE INDEX IF NOT EXISTS payments_taken_at_idx ON payments(taken_at);

--- a/writer-app/database/seed.php
+++ b/writer-app/database/seed.php
@@ -37,6 +37,7 @@ final class Seed
             self::insertItems($pdo);
             self::insertStaff($pdo);
             self::insertOrdersAndItems($pdo);
+            self::insertPayments($pdo);
             $pdo->commit();
         } catch (\Throwable $e) {
             $pdo->rollBack();
@@ -146,6 +147,40 @@ final class Seed
                 }
                 $orderId++;
             }
+        }
+    }
+
+    private static function insertPayments(PDO $pdo): void
+    {
+        $rows = $pdo->query(
+            "SELECT o.id AS order_id, o.closed_at,
+                    COALESCE(SUM(oi.quantity * oi.unit_price_cents), 0) AS total_cents
+               FROM orders o
+          LEFT JOIN order_items oi ON oi.order_id = o.id
+              WHERE o.closed_at IS NOT NULL
+           GROUP BY o.id
+           ORDER BY o.id"
+        )->fetchAll(\PDO::FETCH_ASSOC);
+
+        $paymentStmt = $pdo->prepare(
+            'INSERT INTO payments (order_id, method, amount_cents, taken_at, staff_id)
+             VALUES (:oid, :method, :amount, :taken, :staff)'
+        );
+
+        $baristaIds = [1, 2, 3, 4];
+        $ordinal    = 0;
+        foreach ($rows as $r) {
+            $roll   = mt_rand(1, 100);
+            $method = $roll <= 55 ? 'card' : ($roll <= 85 ? 'cash' : 'mobile');
+            $staff  = $baristaIds[$ordinal % 4];
+            $paymentStmt->execute([
+                'oid'    => (int) $r['order_id'],
+                'method' => $method,
+                'amount' => (int) $r['total_cents'],
+                'taken'  => (string) $r['closed_at'],
+                'staff'  => $staff,
+            ]);
+            $ordinal++;
         }
     }
 

--- a/writer-app/database/seed.php
+++ b/writer-app/database/seed.php
@@ -16,9 +16,8 @@ if (class_exists(Seed::class, false)) {
  * Deterministic coffee-shop seed for the demo.
  *
  * Contract per ADR-002: mt_srand(1); ~90 days of activity ending on a fixed
- * anchor date (2026-08-22 UTC). Reads/writes only the 4 tables A2 defines
- * (categories, items, orders, order_items). A3 extends this to cover staff,
- * payments, and the remaining reports' data needs.
+ * anchor date (2026-08-22 UTC). Populates categories, items, staff, orders,
+ * order_items, payments. A5 will add template_drafts.
  */
 final class Seed
 {
@@ -36,6 +35,7 @@ final class Seed
             self::wipe($pdo);
             self::insertCategories($pdo);
             self::insertItems($pdo);
+            self::insertStaff($pdo);
             self::insertOrdersAndItems($pdo);
             $pdo->commit();
         } catch (\Throwable $e) {
@@ -46,9 +46,11 @@ final class Seed
 
     private static function wipe(PDO $pdo): void
     {
+        $pdo->exec('DELETE FROM payments');
         $pdo->exec('DELETE FROM order_items');
         $pdo->exec('DELETE FROM orders');
         $pdo->exec('DELETE FROM items');
+        $pdo->exec('DELETE FROM staff');
         $pdo->exec('DELETE FROM categories');
     }
 
@@ -84,6 +86,22 @@ final class Seed
         );
         foreach ($catalogue as [$id, $cat, $name, $price]) {
             $stmt->execute(['id' => $id, 'cat' => $cat, 'name' => $name, 'price' => $price]);
+        }
+    }
+
+    private static function insertStaff(PDO $pdo): void
+    {
+        $roster = [
+            [1, 'Ada Lovelace',    'barista'],
+            [2, 'Ben Carson',      'barista'],
+            [3, 'Cleo Diaz',       'barista'],
+            [4, 'Devon Ellis',     'barista'],
+            [5, 'Farah Grant',     'shift_lead'],
+            [6, 'Hiro Yamamoto',   'manager'],
+        ];
+        $stmt = $pdo->prepare('INSERT INTO staff (id, name, role) VALUES (:id, :name, :role)');
+        foreach ($roster as [$id, $name, $role]) {
+            $stmt->execute(['id' => $id, 'name' => $name, 'role' => $role]);
         }
     }
 

--- a/writer-app/tests/Fixtures/coffee-shop-mini.sql
+++ b/writer-app/tests/Fixtures/coffee-shop-mini.sql
@@ -1,0 +1,59 @@
+-- coffee-shop-mini.sql
+--
+-- Deterministic ~20-row fixture shared across A3 snapshot tests.
+-- Anchor date: 2026-08-22 (same as Seed::ANCHOR_DATE).
+--
+-- Edge cases included:
+--   • Sales by Category: multiple categories with different totals
+--   • Open Tabs: order 2000 has closed_at IS NULL
+--   • Sales by Category → Item: multiple items per category, multiple orders per item
+--   • Register Close: two payment methods (cash + card) on 2026-08-22
+--   • Full Menu Book: category has a non-null description column (added in later task if needed)
+
+DELETE FROM payments;
+DELETE FROM order_items;
+DELETE FROM orders;
+DELETE FROM items;
+DELETE FROM staff;
+DELETE FROM categories;
+
+INSERT INTO categories (id, name) VALUES
+    (1, 'Coffee'),
+    (2, 'Pastry');
+
+INSERT INTO items (id, category_id, name, unit_price_cents) VALUES
+    (1, 1, 'Espresso',  500),
+    (2, 1, 'Latte',     600),
+    (3, 2, 'Croissant', 400),
+    (4, 2, 'Muffin',    350);
+
+INSERT INTO staff (id, name, role) VALUES
+    (1, 'Ada Lovelace', 'barista'),
+    (2, 'Farah Grant',  'shift_lead');
+
+-- 2026-08-22 orders (all closed).
+INSERT INTO orders (id, opened_at, closed_at) VALUES
+    (1001, '2026-08-22T09:10:00Z', '2026-08-22T09:15:00Z'),
+    (1002, '2026-08-22T10:20:00Z', '2026-08-22T10:22:00Z'),
+    (1003, '2026-08-22T14:00:00Z', '2026-08-22T14:05:00Z');
+
+INSERT INTO order_items (id, order_id, item_id, quantity, unit_price_cents) VALUES
+    (1, 1001, 1, 1, 500),   -- 500  → order 1001
+    (2, 1001, 3, 1, 400),   -- 400  → order 1001 total 900
+    (3, 1002, 2, 2, 600),   -- 1200 → order 1002 total 1200
+    (4, 1003, 1, 1, 500),   -- 500  → order 1003
+    (5, 1003, 4, 1, 350);   -- 350  → order 1003 total 850
+
+INSERT INTO payments (id, order_id, method, amount_cents, taken_at, staff_id) VALUES
+    (1, 1001, 'card', 900,  '2026-08-22T09:15:00Z', 1),
+    (2, 1002, 'cash', 1200, '2026-08-22T10:22:00Z', 1),
+    (3, 1003, 'card', 850,  '2026-08-22T14:05:00Z', 2);
+
+-- Prior-day order (should be excluded by any date=2026-08-22 filter).
+INSERT INTO orders     (id, opened_at, closed_at)                                  VALUES (999, '2026-08-21T09:00:00Z', '2026-08-21T09:10:00Z');
+INSERT INTO order_items(id, order_id, item_id, quantity, unit_price_cents)         VALUES (99, 999, 2, 1, 600);
+INSERT INTO payments   (id, order_id, method, amount_cents, taken_at, staff_id)    VALUES (99, 999, 'cash', 600, '2026-08-21T09:10:00Z', 1);
+
+-- Open tab (closed_at NULL, no payment) — required by Open Tabs report.
+INSERT INTO orders     (id, opened_at, closed_at)                                  VALUES (2000, '2026-08-22T15:00:00Z', NULL);
+INSERT INTO order_items(id, order_id, item_id, quantity, unit_price_cents)         VALUES (200, 2000, 1, 1, 500);

--- a/writer-app/tests/Unit/Database/CoffeeShopMiniFixtureTest.php
+++ b/writer-app/tests/Unit/Database/CoffeeShopMiniFixtureTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Database;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+
+final class CoffeeShopMiniFixtureTest extends TestCase
+{
+    private const FIXTURE_PATH = __DIR__ . '/../../Fixtures/coffee-shop-mini.sql';
+
+    public function testFixtureLoadsIntoFreshSchemaAndHasExpectedRowCounts(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+        $pdo->exec((string) file_get_contents(self::FIXTURE_PATH));
+
+        $this->assertSame(2, $this->countRows($pdo, 'categories'));
+        $this->assertSame(4, $this->countRows($pdo, 'items'));
+        $this->assertSame(2, $this->countRows($pdo, 'staff'));
+        $this->assertSame(5, $this->countRows($pdo, 'orders'));       // 3 target-day + 1 prior + 1 open
+        $this->assertSame(7, $this->countRows($pdo, 'order_items'));  // 5 target-day + 1 prior + 1 open
+        $this->assertSame(4, $this->countRows($pdo, 'payments'));     // 3 target-day + 1 prior; open tab has none
+    }
+
+    public function testFixtureIncludesOneOpenTab(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+        $pdo->exec((string) file_get_contents(self::FIXTURE_PATH));
+
+        $openCount = (int) $pdo->query('SELECT COUNT(*) FROM orders WHERE closed_at IS NULL')->fetchColumn();
+        $this->assertSame(1, $openCount, 'Open Tabs report needs at least one closed_at IS NULL row');
+    }
+
+    public function testFixturePaymentAmountsMatchOrderTotals(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+        $pdo->exec((string) file_get_contents(self::FIXTURE_PATH));
+
+        $mismatches = $pdo->query(
+            "SELECT p.order_id
+               FROM payments p
+               JOIN (
+                   SELECT order_id, SUM(quantity * unit_price_cents) AS total_cents
+                     FROM order_items
+                    GROUP BY order_id
+               ) t ON t.order_id = p.order_id
+              WHERE p.amount_cents != t.total_cents"
+        )->fetchAll();
+        $this->assertSame([], $mismatches, 'each hand-authored payment.amount_cents must match SUM(order_items)');
+    }
+
+    private function countRows(\PDO $pdo, string $table): int
+    {
+        return (int) $pdo->query("SELECT COUNT(*) FROM {$table}")->fetchColumn();
+    }
+}

--- a/writer-app/tests/Unit/Database/SeedDeterminismTest.php
+++ b/writer-app/tests/Unit/Database/SeedDeterminismTest.php
@@ -35,6 +35,8 @@ final class SeedDeterminismTest extends TestCase
             'items'       => $pdo->query('SELECT * FROM items       ORDER BY id')->fetchAll(),
             'orders'      => $pdo->query('SELECT * FROM orders      ORDER BY id')->fetchAll(),
             'order_items' => $pdo->query('SELECT * FROM order_items ORDER BY id')->fetchAll(),
+            'payments'    => $pdo->query('SELECT * FROM payments    ORDER BY id')->fetchAll(),
+            'staff'       => $pdo->query('SELECT * FROM staff       ORDER BY id')->fetchAll(),
         ];
     }
 }

--- a/writer-app/tests/Unit/Database/SeedPaymentsTest.php
+++ b/writer-app/tests/Unit/Database/SeedPaymentsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Database;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+
+final class SeedPaymentsTest extends TestCase
+{
+    public function testEveryClosedOrderHasExactlyOnePayment(): void
+    {
+        $pdo = $this->seededPdo();
+
+        $closedOrders = (int) $pdo->query(
+            'SELECT COUNT(*) FROM orders WHERE closed_at IS NOT NULL'
+        )->fetchColumn();
+        $paymentCount = (int) $pdo->query('SELECT COUNT(*) FROM payments')->fetchColumn();
+
+        $this->assertGreaterThan(0, $closedOrders, 'seed should have at least one closed order');
+        $this->assertSame(
+            $closedOrders,
+            $paymentCount,
+            'payments must be 1:1 with closed orders (A3.1 v1: single payment per order)'
+        );
+    }
+
+    public function testPaymentAmountsMatchOrderTotals(): void
+    {
+        $pdo = $this->seededPdo();
+
+        $mismatches = $pdo->query(
+            "SELECT p.order_id
+               FROM payments p
+               JOIN (
+                   SELECT order_id, SUM(quantity * unit_price_cents) AS total_cents
+                     FROM order_items
+                    GROUP BY order_id
+               ) t ON t.order_id = p.order_id
+              WHERE p.amount_cents != t.total_cents"
+        )->fetchAll();
+
+        $this->assertSame([], $mismatches, 'each payment.amount_cents must equal SUM(order_items) for that order');
+    }
+
+    public function testPaymentMethodsAreLimitedToTheThreeAllowed(): void
+    {
+        $pdo = $this->seededPdo();
+
+        $methods = $pdo->query('SELECT DISTINCT method FROM payments')->fetchAll(\PDO::FETCH_COLUMN);
+        sort($methods);
+        $this->assertSame(['card', 'cash', 'mobile'], $methods);
+    }
+
+    public function testStaffIdIsAValidStaffRow(): void
+    {
+        $pdo = $this->seededPdo();
+
+        $orphans = (int) $pdo->query(
+            'SELECT COUNT(*) FROM payments WHERE staff_id NOT IN (SELECT id FROM staff)'
+        )->fetchColumn();
+
+        $this->assertSame(0, $orphans);
+    }
+
+    private function seededPdo(): \PDO
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+        require __DIR__ . '/../../../database/seed.php';
+        \ReportWriter\App\Database\Seed::run($pdo);
+        return $pdo;
+    }
+}

--- a/writer-app/tests/Unit/Database/SeedStaffTest.php
+++ b/writer-app/tests/Unit/Database/SeedStaffTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Database;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+
+final class SeedStaffTest extends TestCase
+{
+    public function testSeedPopulatesStaffTable(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../../database/schema.sql'
+        );
+
+        require __DIR__ . '/../../../database/seed.php';
+        \ReportWriter\App\Database\Seed::run($pdo);
+
+        $rows = $pdo->query('SELECT id, name, role FROM staff ORDER BY id')->fetchAll(\PDO::FETCH_ASSOC);
+
+        // Six-person fixed roster: 4 baristas, 1 shift lead, 1 manager.
+        $this->assertCount(6, $rows);
+        $this->assertSame([1, 2, 3, 4, 5, 6], array_column($rows, 'id'));
+
+        $roleCounts = array_count_values(array_column($rows, 'role'));
+        $this->assertSame(4, $roleCounts['barista'] ?? 0);
+        $this->assertSame(1, $roleCounts['shift_lead'] ?? 0);
+        $this->assertSame(1, $roleCounts['manager'] ?? 0);
+
+        // Every staff row has a non-empty name.
+        foreach ($rows as $row) {
+            $this->assertNotEmpty($row['name'], 'staff.name must be non-empty');
+        }
+    }
+}

--- a/writer-app/tests/Unit/Database/SqliteConnectionFactoryTest.php
+++ b/writer-app/tests/Unit/Database/SqliteConnectionFactoryTest.php
@@ -22,7 +22,7 @@ final class SqliteConnectionFactoryTest extends TestCase
         $tables = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
                        ->fetchAll(PDO::FETCH_COLUMN);
 
-        $this->assertSame(['categories', 'items', 'order_items', 'orders'], $tables);
+        $this->assertSame(['categories', 'items', 'order_items', 'orders', 'payments', 'staff'], $tables);
     }
 
     public function testCreatesFileBackedPdo(): void


### PR DESCRIPTION
## Summary
- **Schema:** add `staff (id, name, role)` and `payments (id, order_id, method, amount_cents, taken_at, staff_id)` tables with supporting indexes. Existing tables unchanged.
- **Seed:** `Seed::run()` now populates staff (fixed six-person roster, no PRNG draws) and payments (1:1 with closed orders, deterministic method mix). `Seed::wipe()` extended in FK-safe order.
- **Fixtures:** bootstrap `writer-app/tests/Fixtures/coffee-shop-mini.sql` — a ~20-row hand-authored dataset covering all six tables + the edge cases A3.2–A3.6 need (multi-category totals, at least one open tab, prior-day exclusion row, per-method payment mix).
- **Tests:** new `SeedStaffTest`, `SeedPaymentsTest` (4 invariants on 1:1 + amount + method + FK), `CoffeeShopMiniFixtureTest` (3 tests). `SeedDeterminismTest` extended to dump the two new tables.

Orders + order_items output is byte-identical to `main` (verified via PHP dump + diff — PRNG stream unchanged because `insertStaff` uses no `mt_rand` draws and `insertPayments` runs after `insertOrdersAndItems`).

Design: `docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md` § A3.1.
Plan:   `docs/superpowers/plans/2026-08-23-a3.1-schema-and-seed-extension.md`.

## Deviations from the plan (all minor, documented for reviewer)
1. `SqliteConnectionFactoryTest::testCreatesInMemoryPdoWithSchemaLoaded` asserts the exact list of tables loaded from schema.sql — plan predicted this would stay green but it fails when the table list grows. Updated the expected array to include `payments`, `staff` (still alphabetical).
2. Plan's `CoffeeShopMiniFixtureTest::count()` collides with `PHPUnit\Framework\TestCase::count()` (public via `Countable`). Renamed helper to `countRows()`.
3. Plan's `assertSame(8, order_items)` was off by one — fixture has 5 target-day + 1 prior + 1 open = 7. Corrected expectation.
4. Step 4 byte-identical verification uses in-process PHP dump + branch checkout swap (simpler + avoids the plan's docker container-name reuse gymnastics). Same guarantee.

## Test plan
- [x] `cd writer && vendor/bin/phpunit` → `OK (163 tests, 300 assertions)` — unchanged
- [x] `cd writer-app && vendor/bin/phpunit` → `OK (38 tests, 85 assertions)` (30 baseline + 8 new)
- [x] `./scripts/demo-up` succeeds; `sqlite3` count of staff = 6, payments = 1511 (= closed orders)
- [x] Byte-identical orders + order_items vs `main` (diff = empty)