### PR TITLE
docs(plans): A3.3 Open Tabs implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-08-23-a3.3-open-tabs.md
+++ b/docs/superpowers/plans/2026-08-23-a3.3-open-tabs.md
@@ -1,0 +1,834 @@
+# A3.3 — Open Tabs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the "Open Tabs" report as the second `DefinitionFiller`-driven (JSON-templated) report in the demo. This plan is intentionally lean because A3.2 already landed the reusable scaffolding (`JsonTemplateRepository`, `DataSourceRegistry` + `DefinitionFillerFactory` wiring, `SnapshotAssertions` trait). A3.3 exists mainly to prove that the A3.2 pattern generalizes to a second report with a different shape — no grouping, no footer aggregate, no params.
+
+**Architecture:** Single band-flavor detail-only report driven by a JSON template. New `SqliteOpenTabsProvider` returns `{order_id, opened_at, running_total_cents}` rows for every order with `closed_at IS NULL`, ordered by `opened_at ASC`. The provider registers under name `open-tabs` in the container's shared `DataSourceRegistry`. A new `open-tabs.filler` service resolves to a `DefinitionFiller` created from `writer-app/templates/open-tabs.json`. `ReportRegistry` gains one entry. Snapshot test reuses the `SnapshotAssertions` trait from A3.2 — no new infrastructure.
+
+**Tech Stack:** PHP 7.4+, PDO-SQLite, PHPUnit 9.5, Slim 4 (routing untouched). No frontend changes. No library (`writer/`) changes.
+
+**Sub-project ticket:** [012 — Sub-project A](../../tickets/012-implement-standalone-runtime-subproject-a.md) — A3.3 of A3.
+**Design spec:** [2026-08-23-a3-sample-reports-design.md](../specs/2026-08-23-a3-sample-reports-design.md) § A3.3.
+**Predecessor plan:** [A3.2 Sales by Category](2026-08-23-a3.2-sales-by-category.md) — this plan assumes its infrastructure landed on `main`.
+
+**Related decisions:**
+- [ADR-002](../../09-conventions/decisions/002-sqlite-coffee-shop-toy-domain.md) — SQLite + coffee-shop domain
+- [ADR-011](../../09-conventions/decisions/011-docs-after-implementation.md) — no doc pages for code that doesn't exist yet
+- [ADR-013](../../09-conventions/decisions/013-framework-agnostic-library.md) — `writer-app/` is dev/test/demo scaffolding
+
+**Prerequisites:**
+- **A3.1 and A3.2 landed on `main`.** A3.3 reuses A3.1's `coffee-shop-mini.sql` fixture (Task 4 snapshot) and A3.2's `JsonTemplateRepository` / `DataSourceRegistry` / `DefinitionFillerFactory` / `SnapshotAssertions` trait / `sales-by-category.filler` service pattern.
+- Green suites on `main`:
+  - `cd writer && vendor/bin/phpunit` → `OK (163 tests, 300 assertions)`
+  - `cd writer-app && vendor/bin/phpunit` → `OK (58 tests, …)` after A3.2 lands
+- Docker available for the Task 6 end-to-end check.
+
+**Working directory:**
+- All PHP commands run from `/Users/leejenkins/dev/report-writer/writer-app/`.
+- Git commands run from `/Users/leejenkins/dev/report-writer/`.
+
+---
+
+## File Structure
+
+Everything new or modified is under `writer-app/`. Library (`writer/`) is not touched.
+
+```
+writer-app/
+├── src/
+│   ├── Kernel.php                                       # MODIFY — register SqliteOpenTabsProvider in DI + add source to DataSourceRegistry factory + register open-tabs.filler + add ReportDefinition
+│   └── Reports/
+│       └── DataSource/
+│           └── SqliteOpenTabsProvider.php               # NEW — one row per orders row where closed_at IS NULL
+├── templates/
+│   └── open-tabs.json                                   # NEW — no grouping, no summary, no params
+└── tests/
+    ├── Snapshots/
+    │   └── open-tabs.html                               # NEW — pinned HTML against coffee-shop-mini.sql
+    └── Unit/
+        └── Reports/
+            ├── OpenTabsSnapshotTest.php                 # NEW — uses SnapshotAssertions trait from A3.2
+            └── DataSource/
+                └── SqliteOpenTabsProviderTest.php       # NEW — row shape + closed-at-null filter + ordering
+```
+
+**File responsibilities:**
+
+- `SqliteOpenTabsProvider.php` — implements `ReportDataSourceInterface::fetchRows()`. Ignores `$params` entirely (A3 spec keeps A3.3 param-less for simplicity). SQL selects from `orders` where `closed_at IS NULL`, sums `qty * unit_price_cents` per order via LEFT JOIN on `order_items`, orders by `opened_at ASC`. Formats `opened_at` as `YYYY-MM-DD HH:MM` via SQLite's `strftime()`.
+- `open-tabs.json` — three bands: title, column-header, detail. No summary. No params. `data_source: "open-tabs"`.
+- `OpenTabsSnapshotTest.php` — mirrors `SalesByCategorySnapshotTest` structure but wires up `SqliteOpenTabsProvider` + `open-tabs.json`. Uses the shared `SnapshotAssertions` trait; refresh via `UPDATE_SNAPSHOTS=1`.
+- `Kernel.php` — three small additions (see Task 3): factory for the new provider, one line inside the existing `DataSourceRegistry` factory to `register()` it, and a `open-tabs.filler` service. The `ReportRegistry` factory gains one entry.
+
+---
+
+## Task 0: Verify baseline
+
+- [ ] **Step 1: Confirm branch state**
+
+Run: `git -C /Users/leejenkins/dev/report-writer status`
+Expected: `On branch main`, working tree clean, in sync with `origin/main`.
+
+- [ ] **Step 2: Confirm A3.2 landed**
+
+Run: `test -f /Users/leejenkins/dev/report-writer/writer-app/src/Reports/JsonTemplateRepository.php \
+   && test -f /Users/leejenkins/dev/report-writer/writer-app/tests/Support/SnapshotAssertions.php \
+   && test -f /Users/leejenkins/dev/report-writer/writer-app/templates/sales-by-category.json \
+   && echo OK`
+Expected: `OK`. If it prints nothing, A3.2 is not merged yet — stop and wait.
+
+- [ ] **Step 3: Confirm existing tests are green**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (58 tests, …)` (A3.2 baseline: 38 from A3.1 + 20 from A3.2).
+
+- [ ] **Step 4: Cut a feature branch**
+
+Run: `git -C /Users/leejenkins/dev/report-writer checkout -b feat/a3.3-open-tabs`
+Expected: `Switched to a new branch 'feat/a3.3-open-tabs'`.
+
+---
+
+## Task 1: Add `SqliteOpenTabsProvider` (TDD)
+
+**Files:**
+- Create: `writer-app/tests/Unit/Reports/DataSource/SqliteOpenTabsProviderTest.php`
+- Create: `writer-app/src/Reports/DataSource/SqliteOpenTabsProvider.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `writer-app/tests/Unit/Reports/DataSource/SqliteOpenTabsProviderTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports\DataSource;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider;
+
+final class SqliteOpenTabsProviderTest extends TestCase
+{
+    private const FIXTURE = __DIR__ . '/../../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA  = __DIR__ . '/../../../../database/schema.sql';
+
+    public function testFetchRowsReturnsOnlyOrdersWithClosedAtNull(): void
+    {
+        $rows = $this->fetch();
+
+        // coffee-shop-mini.sql has exactly one open tab: order 2000, opened at
+        // 2026-08-22T15:00:00Z, one espresso @ 500 cents. All other orders
+        // (1001, 1002, 1003, 999) have closed_at set and must be excluded.
+        $this->assertSame(
+            [
+                [
+                    'order_id'            => 2000,
+                    'opened_at'           => '2026-08-22 15:00',
+                    'running_total_cents' => 500,
+                ],
+            ],
+            $rows
+        );
+    }
+
+    public function testFetchRowsIgnoresParams(): void
+    {
+        // A3.3 is param-less. Passing arbitrary params must not change output
+        // or throw — the provider should not read $params at all.
+        $this->assertSame(
+            $this->fetch(),
+            (new SqliteOpenTabsProvider($this->seededPdo()))->fetchRows(['date' => '2026-08-22', 'garbage' => 'x'])
+        );
+    }
+
+    public function testFetchRowsOrdersByOpenedAtAscending(): void
+    {
+        // Inject a second open tab that opened before the fixture's 15:00 tab
+        // and verify the older tab lists first. Uses the same in-memory PDO
+        // so the fixture stays untouched on disk.
+        $pdo = $this->seededPdo();
+        $pdo->exec("INSERT INTO orders (id, opened_at, closed_at)
+                    VALUES (2001, '2026-08-22T08:30:00Z', NULL)");
+        $pdo->exec("INSERT INTO order_items (id, order_id, item_id, quantity, unit_price_cents)
+                    VALUES (201, 2001, 2, 1, 600)");
+
+        $rows = (new SqliteOpenTabsProvider($pdo))->fetchRows([]);
+        $orderIds = array_column($rows, 'order_id');
+        $this->assertSame([2001, 2000], $orderIds, 'earlier opened_at must appear first');
+    }
+
+    public function testFetchRowsReturnsEmptyWhenNoOpenTabsExist(): void
+    {
+        $pdo = $this->seededPdo();
+        // Close the one open tab in the fixture.
+        $pdo->exec("UPDATE orders SET closed_at = '2026-08-22T15:05:00Z' WHERE id = 2000");
+        $this->assertSame([], (new SqliteOpenTabsProvider($pdo))->fetchRows([]));
+    }
+
+    public function testFetchRowsHandlesOpenTabWithZeroItems(): void
+    {
+        // An open tab with no order_items must appear with running_total_cents = 0.
+        $pdo = $this->seededPdo();
+        $pdo->exec("INSERT INTO orders (id, opened_at, closed_at)
+                    VALUES (2002, '2026-08-22T16:00:00Z', NULL)");
+        // Deliberately NOT adding any order_items for 2002.
+
+        $rows = (new SqliteOpenTabsProvider($pdo))->fetchRows([]);
+        $totals = [];
+        foreach ($rows as $r) {
+            $totals[$r['order_id']] = $r['running_total_cents'];
+        }
+        $this->assertSame(0, $totals[2002] ?? null, 'zero-item open tab must have 0 running total');
+    }
+
+    /**
+     * @return array<int, array{order_id: int, opened_at: string, running_total_cents: int}>
+     */
+    private function fetch(): array
+    {
+        return (new SqliteOpenTabsProvider($this->seededPdo()))->fetchRows([]);
+    }
+
+    private function seededPdo(): \PDO
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+        return $pdo;
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SqliteOpenTabsProviderTest`
+Expected: fatal `Class "ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider" not found`.
+
+- [ ] **Step 3: Implement the provider**
+
+Create `writer-app/src/Reports/DataSource/SqliteOpenTabsProvider.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Reports\DataSource;
+
+use PDO;
+use ReportWriter\Interfaces\ReportDataSourceInterface;
+
+final class SqliteOpenTabsProvider implements ReportDataSourceInterface
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * A3.3 is param-less; $params is ignored.
+     *
+     * @param  array<string, mixed> $params
+     * @return array<int, array{order_id: int, opened_at: string, running_total_cents: int}>
+     */
+    public function fetchRows(array $params): array
+    {
+        $sql = <<<SQL
+            SELECT
+                o.id                                                       AS order_id,
+                strftime('%Y-%m-%d %H:%M', o.opened_at)                    AS opened_at,
+                COALESCE(SUM(oi.quantity * oi.unit_price_cents), 0)        AS running_total_cents
+            FROM orders o
+            LEFT JOIN order_items oi ON oi.order_id = o.id
+            WHERE o.closed_at IS NULL
+            GROUP BY o.id, o.opened_at
+            ORDER BY o.opened_at ASC, o.id ASC
+        SQL;
+
+        $stmt = $this->pdo->query($sql);
+
+        return array_map(
+            static fn (array $r): array => [
+                'order_id'            => (int)    $r['order_id'],
+                'opened_at'           => (string) $r['opened_at'],
+                'running_total_cents' => (int)    $r['running_total_cents'],
+            ],
+            $stmt->fetchAll()
+        );
+    }
+}
+```
+
+Notes on the SQL:
+- `LEFT JOIN` (not INNER) so open tabs with zero items still appear with running_total 0 — covered by `testFetchRowsHandlesOpenTabWithZeroItems`.
+- `COALESCE(..., 0)` because `SUM()` over an empty set returns NULL in SQLite.
+- `o.id ASC` as tiebreaker for equal `opened_at` — keeps snapshot output deterministic.
+- No prepared parameters → `query()` is fine (no user input reaches the SQL).
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SqliteOpenTabsProviderTest`
+Expected: `OK (5 tests, …)`.
+
+- [ ] **Step 5: Confirm no regression**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (63 tests, …)` (58 baseline + 5 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/src/Reports/DataSource/SqliteOpenTabsProvider.php \
+        writer-app/tests/Unit/Reports/DataSource/SqliteOpenTabsProviderTest.php
+git commit -m "feat(reports): SqliteOpenTabsProvider (A3.3)"
+```
+
+---
+
+## Task 2: Author `open-tabs.json`
+
+**Files:**
+- Create: `writer-app/templates/open-tabs.json`
+
+Validated implicitly by the snapshot test in Task 4.
+
+- [ ] **Step 1: Author the JSON template**
+
+Create `writer-app/templates/open-tabs.json`:
+
+```json
+{
+  "report_definition_id": "open-tabs",
+  "data_source": "open-tabs",
+  "bands": [
+    {
+      "id": "title",
+      "type": "title",
+      "elements": [
+        {
+          "id": "title_text",
+          "x": 0, "width": 0, "height": 24, "align": "center",
+          "content": { "type": "text", "value": "Open Tabs" }
+        }
+      ]
+    },
+    {
+      "id": "col_header",
+      "type": "col-header",
+      "elements": [
+        {
+          "id": "hdr_order",
+          "x": 0, "width": 120, "height": 16, "align": "left",
+          "content": { "type": "text", "value": "Order" }
+        },
+        {
+          "id": "hdr_opened",
+          "x": 120, "width": 200, "height": 16, "align": "left",
+          "content": { "type": "text", "value": "Opened" }
+        },
+        {
+          "id": "hdr_running_total",
+          "x": 320, "width": 160, "height": 16, "align": "right",
+          "content": { "type": "text", "value": "Running Total" }
+        }
+      ]
+    },
+    {
+      "id": "detail",
+      "type": "detail",
+      "elements": [
+        {
+          "id": "order_id",
+          "x": 0, "width": 120, "height": 14, "align": "left",
+          "content": { "type": "field", "field": "order_id" }
+        },
+        {
+          "id": "opened_at",
+          "x": 120, "width": 200, "height": 14, "align": "left",
+          "content": { "type": "field", "field": "opened_at" }
+        },
+        {
+          "id": "running_total",
+          "x": 320, "width": 160, "height": 14, "align": "right",
+          "content": { "type": "field", "field": "running_total_cents", "format": "cents" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Notes:
+- No `"params"` block — A3.3 is param-less.
+- No `"summary"` band — per spec, "no footer aggregate."
+- `title` band uses `width: 0` (the Ticket 017 element-width sentinel) so it centers on the printable page width.
+- `format: "cents"` matches the formatter installed by `FormatterRegistry::defaults()`.
+
+- [ ] **Step 2: Verify the JSON parses via TemplateLoader**
+
+Run:
+```bash
+cd /Users/leejenkins/dev/report-writer/writer-app && \
+php -r 'require "vendor/autoload.php"; \
+    $t = (new ReportWriter\Template\TemplateLoader())->load(__DIR__ . "/templates/open-tabs.json"); \
+    echo "id=" . $t->getReportDefinitionId() . " bands=" . count($t->getBands()) . PHP_EOL;'
+```
+Expected: `id=open-tabs bands=3`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/templates/open-tabs.json
+git commit -m "feat(templates): open-tabs JSON template (A3.3)"
+```
+
+---
+
+## Task 3: Wire the provider + filler + registry entry in `Kernel.php`
+
+**Files:**
+- Modify: `writer-app/src/Kernel.php`
+- Create: `writer-app/tests/Unit/ContainerA33WiringTest.php`
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Create `writer-app/tests/Unit/ContainerA33WiringTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Config;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Kernel;
+use ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider;
+use ReportWriter\App\Reports\ReportRegistry;
+use ReportWriter\Fill\DefinitionFiller;
+use ReportWriter\Registry\DataSourceRegistry;
+
+final class ContainerA33WiringTest extends TestCase
+{
+    private function container(): \ReportWriter\App\Container
+    {
+        // Same pattern used by A3.2's ContainerA32WiringTest: direct-construct
+        // Config with ':memory:' sqlitePath so Kernel doesn't guard-throw, then
+        // overwrite PDO with a schema-loaded in-memory connection.
+        $c = Kernel::defaultContainer(new Config(':memory:', false));
+        $c->set(PDO::class, static fn () => SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../database/schema.sql'
+        ));
+        return $c;
+    }
+
+    public function testDataSourceRegistryContainsOpenTabsSource(): void
+    {
+        $registry = $this->container()->get(DataSourceRegistry::class);
+        $this->assertTrue($registry->has('open-tabs'));
+        $this->assertInstanceOf(SqliteOpenTabsProvider::class, $registry->get('open-tabs'));
+    }
+
+    public function testDataSourceRegistryStillContainsSalesByCategorySource(): void
+    {
+        // Regression guard: A3.3 must not accidentally overwrite A3.2's registration.
+        $registry = $this->container()->get(DataSourceRegistry::class);
+        $this->assertTrue($registry->has('sales-by-category'));
+    }
+
+    public function testOpenTabsFillerServiceReturnsADefinitionFiller(): void
+    {
+        $filler = $this->container()->get('open-tabs.filler');
+        $this->assertInstanceOf(DefinitionFiller::class, $filler);
+    }
+
+    public function testReportRegistryExposesOpenTabsDefinition(): void
+    {
+        $registry = $this->container()->get(ReportRegistry::class);
+        $def = $registry->get('open-tabs');
+        $this->assertSame('open-tabs', $def->getId());
+        $this->assertSame('Open Tabs', $def->getLabel());
+        $this->assertSame('open-tabs.filler', $def->getFillerServiceId());
+        $this->assertSame([], $def->getParams(), 'A3.3 is param-less');
+    }
+
+    public function testReportRegistryStillExposesPredecessorReports(): void
+    {
+        // Regression guard.
+        $registry = $this->container()->get(ReportRegistry::class);
+        $this->assertSame('daily-sales',       $registry->get('daily-sales')->getId());
+        $this->assertSame('sales-by-category', $registry->get('sales-by-category')->getId());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter ContainerA33WiringTest`
+Expected: first three tests fail (open-tabs source + filler + definition all absent). The two regression-guard tests should pass unchanged.
+
+- [ ] **Step 3: Wire the new services in `Kernel.php`**
+
+Open `writer-app/src/Kernel.php`. Add one `use` line (keep the block alphabetical):
+
+```php
+use ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider;
+```
+
+Register the provider factory near the existing `SqliteSalesByCategoryProvider` block:
+
+```php
+        $c->set(SqliteOpenTabsProvider::class,
+            static fn (Container $c) => new SqliteOpenTabsProvider($c->get(PDO::class)));
+```
+
+Extend the existing `DataSourceRegistry` factory to add the new source (one added line):
+
+```php
+        $c->set(DataSourceRegistry::class, static function (Container $c): DataSourceRegistry {
+            $registry = new DataSourceRegistry();
+            $registry->register('sales-by-category', $c->get(SqliteSalesByCategoryProvider::class));
+            $registry->register('open-tabs',         $c->get(SqliteOpenTabsProvider::class));  // ← NEW
+            return $registry;
+        });
+```
+
+Register the per-JSON-report filler service (mirrors `sales-by-category.filler`):
+
+```php
+        $c->set('open-tabs.filler', static function (Container $c): DefinitionFiller {
+            /** @var JsonTemplateRepository $repo */
+            $repo = $c->get(JsonTemplateRepository::class);
+            /** @var DefinitionFillerFactory $factory */
+            $factory = $c->get(DefinitionFillerFactory::class);
+            return $factory->create($repo->load('open-tabs'));
+        });
+```
+
+Extend the `ReportRegistry` factory with one new `ReportDefinition`:
+
+```php
+        $c->set(ReportRegistry::class, static fn () => new ReportRegistry([
+            new ReportDefinition(
+                'daily-sales',
+                'Daily Sales',
+                DailySalesFiller::class,
+                [new ParamSpec('date', 'date', true)]
+            ),
+            new ReportDefinition(
+                'sales-by-category',
+                'Sales by Category',
+                'sales-by-category.filler',
+                [new ParamSpec('date', 'date', true)]
+            ),
+            new ReportDefinition(          // ← NEW
+                'open-tabs',
+                'Open Tabs',
+                'open-tabs.filler',
+                []
+            ),
+        ]));
+```
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter ContainerA33WiringTest`
+Expected: `OK (5 tests, …)`.
+
+- [ ] **Step 5: Confirm no regression across the whole suite**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (68 tests, …)` (63 after Task 1 + 5 wiring tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/src/Kernel.php writer-app/tests/Unit/ContainerA33WiringTest.php
+git commit -m "feat(kernel): wire SqliteOpenTabsProvider + open-tabs.filler (A3.3)"
+```
+
+---
+
+## Task 4: Snapshot test + snapshot file
+
+**Files:**
+- Create: `writer-app/tests/Unit/Reports/OpenTabsSnapshotTest.php`
+- Create: `writer-app/tests/Snapshots/open-tabs.html`
+
+The `SnapshotAssertions` trait already exists at `writer-app/tests/Support/SnapshotAssertions.php` (landed in A3.2 Task 5). Reuse it as-is.
+
+- [ ] **Step 1: Write the snapshot test**
+
+Create `writer-app/tests/Unit/Reports/OpenTabsSnapshotTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider;
+use ReportWriter\App\Reports\JsonTemplateRepository;
+use ReportWriter\App\Tests\Support\SnapshotAssertions;
+use ReportWriter\Fill\DefinitionFillerFactory;
+use ReportWriter\Layout\Flattener;
+use ReportWriter\Layout\LayoutService;
+use ReportWriter\Layout\PageConfig;
+use ReportWriter\Registry\DataSourceRegistry;
+use ReportWriter\Registry\FormatterRegistry;
+use ReportWriter\Renderer\HtmlRenderer;
+use ReportWriter\Template\TemplateLoader;
+
+final class OpenTabsSnapshotTest extends TestCase
+{
+    use SnapshotAssertions;
+
+    private const FIXTURE       = __DIR__ . '/../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA        = __DIR__ . '/../../../database/schema.sql';
+    private const TEMPLATES_DIR = __DIR__ . '/../../../templates';
+    private const SNAPSHOT      = __DIR__ . '/../../Snapshots/open-tabs.html';
+
+    public function testRendersByteForByteMatchOfSnapshotOnFixture(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+
+        $registry = new DataSourceRegistry();
+        $registry->register('open-tabs', new SqliteOpenTabsProvider($pdo));
+
+        $factory = new DefinitionFillerFactory($registry, FormatterRegistry::defaults());
+        $repo    = new JsonTemplateRepository(self::TEMPLATES_DIR, new TemplateLoader());
+
+        $filler   = $factory->create($repo->load('open-tabs'));
+        $instance = $filler->fill([]);  // A3.3 is param-less
+
+        $page   = new PageConfig();
+        $stream = (new LayoutService(new Flattener(), $page))->layout($instance);
+        $html   = (new HtmlRenderer($page))->render($stream);
+
+        $this->assertSnapshotMatches($html, self::SNAPSHOT);
+    }
+}
+```
+
+- [ ] **Step 2: Bootstrap the snapshot**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter OpenTabsSnapshotTest`
+Expected: `1) …testRendersByteForByteMatchOfSnapshotOnFixture` fails with `Snapshot bootstrapped at .../open-tabs.html. Re-run the test to verify.`
+
+- [ ] **Step 3: Verify the bootstrapped snapshot contains the expected content**
+
+Automated check:
+
+```bash
+cd /Users/leejenkins/dev/report-writer/writer-app && \
+for token in 'Open Tabs' 'Order' 'Opened' 'Running Total' '2000' '2026-08-22 15:00' '$5.00'; do
+    if ! grep -qF "$token" tests/Snapshots/open-tabs.html; then
+        echo "MISSING: $token" && exit 1
+    fi
+done
+echo OK
+```
+
+Expected: `OK`. Fixture-derived expectations:
+- Title band: "Open Tabs" (centered)
+- Column headers: "Order", "Opened", "Running Total"
+- One detail row: order 2000 | 2026-08-22 15:00 | $5.00
+
+If any token is missing:
+- No detail row → provider filter is wrong (should be `closed_at IS NULL`, not `IS NOT NULL`).
+- Wrong $ amount → `format: "cents"` not applied, or LEFT JOIN is INNER (drops zero-item rows).
+- Column layout wrong → `x`/`width` in the JSON off.
+
+Do NOT rerun with `UPDATE_SNAPSHOTS=1` until the failure is understood.
+
+Optional (when a human is present): open `writer-app/tests/Snapshots/open-tabs.html` in a browser.
+
+- [ ] **Step 4: Rerun to confirm GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter OpenTabsSnapshotTest`
+Expected: `OK (1 test, 1 assertion)`.
+
+- [ ] **Step 5: Confirm no regression**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (69 tests, …)` (68 after Task 3 + 1 snapshot test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/tests/Unit/Reports/OpenTabsSnapshotTest.php \
+        writer-app/tests/Snapshots/open-tabs.html
+git commit -m "test(reports): snapshot Open Tabs (A3.3)"
+```
+
+---
+
+## Task 5: Smoke test — the report is reachable via HTTP
+
+**Files:**
+- Modify: `writer-app/tests/Smoke/ReportRenderSmokeTest.php`
+
+Same shape as A3.2 Task 6.
+
+- [ ] **Step 1: Add a third test method to the existing smoke file**
+
+Append (matching the file's style — reuse whatever boot/request helpers the existing Daily Sales / Sales by Category smoke tests use):
+
+```php
+    public function testOpenTabsRespondsWithHtml(): void
+    {
+        $app      = self::bootApp();
+        $request  = self::request('GET', '/api/reports/open-tabs');  // no query params
+        $response = $app->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+        $body = (string) $response->getBody();
+        self::assertStringContainsString('Open Tabs', $body);
+    }
+```
+
+If the existing helpers have different names, use whichever the two existing smoke tests use. The contract (boot → request → handle → 200 + HTML + substring) is what matters.
+
+- [ ] **Step 2: Run the smoke test**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --testsuite Smoke`
+Expected: three smoke tests pass (Daily Sales, Sales by Category, Open Tabs).
+
+Fallback if the suite name differs: `vendor/bin/phpunit tests/Smoke/ReportRenderSmokeTest.php`.
+
+- [ ] **Step 3: Full suite green**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (70 tests, …)`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/tests/Smoke/ReportRenderSmokeTest.php
+git commit -m "test(smoke): /api/reports/open-tabs returns HTML (A3.3)"
+```
+
+---
+
+## Task 6: End-to-end verification + push + PR
+
+- [ ] **Step 1: Confirm the library suite is unaffected**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer && vendor/bin/phpunit`
+Expected: `OK (163 tests, 300 assertions)` — unchanged from baseline.
+
+- [ ] **Step 2: Bring the demo up**
+
+Run: `cd /Users/leejenkins/dev/report-writer && ./scripts/demo-up`
+Wait for the "Demo is up" banner.
+
+- [ ] **Step 3: Hit the new endpoint**
+
+Run:
+```bash
+curl -sS -D - 'http://localhost:8090/api/reports/open-tabs' -o /tmp/opentabs.html | head -5
+```
+Expected header block: `HTTP/1.1 200 OK`, `Content-Type: text/html; charset=utf-8`.
+
+Then:
+```bash
+grep -c 'Open Tabs' /tmp/opentabs.html
+```
+Expected: `1` or greater.
+
+Note the row count is data-dependent — the demo seed produces many open tabs (see A3.1 seed output where "payments=1511 = # closed orders", implying `total_orders - 1511` open tabs). Do not pin an exact count in this step.
+
+- [ ] **Step 4: Verify predecessor reports still work**
+
+Run:
+```bash
+for id in daily-sales 'sales-by-category?date=2026-08-22' open-tabs; do
+    printf '%-40s ' "/api/reports/$id"
+    curl -sS -o /dev/null -w '%{http_code}\n' "http://localhost:8090/api/reports/$id"
+done
+```
+Expected: three `200` lines.
+
+- [ ] **Step 5: (Optional) browser smoke**
+
+Open `http://localhost:8090/api/reports/open-tabs` in a browser. Confirm the title reads "Open Tabs", column headers are Order / Opened / Running Total, and the demo seed produces a plausible list (opened dates within the seed's ~90-day window ending 2026-08-22).
+
+- [ ] **Step 6: Tear down (or leave up for A3.4)**
+
+Run: `cd /Users/leejenkins/dev/report-writer && docker compose down`
+
+- [ ] **Step 7: Push the branch and open the PR**
+
+```bash
+git -C /Users/leejenkins/dev/report-writer push -u origin feat/a3.3-open-tabs
+
+gh pr create --repo edgecase123/report-writer \
+  --title "feat(A3.3): Open Tabs report" \
+  --body "$(cat <<'EOF'
+## Summary
+- **New report:** \`GET /api/reports/open-tabs\` — one row per order with \`closed_at IS NULL\`, ordered by \`opened_at ASC\`. No params, no grouping, no footer aggregate.
+- **New provider:** \`SqliteOpenTabsProvider\` returns \`{order_id, opened_at, running_total_cents}\`. LEFT JOIN + COALESCE so open tabs with zero items still appear with 0 running total.
+- **Reuses A3.2 infrastructure:** \`JsonTemplateRepository\`, \`DataSourceRegistry\`, \`DefinitionFillerFactory\`, \`SnapshotAssertions\` trait — all landed by A3.2, this PR adds one \`register()\` call and one \`{id}.filler\` service.
+- Snapshot pinned against A3.1's \`coffee-shop-mini.sql\` fixture: order 2000 | 2026-08-22 15:00 | $5.00.
+
+Design: [A3 spec](docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md) § A3.3.
+Plan: [A3.3 plan](docs/superpowers/plans/2026-08-23-a3.3-open-tabs.md).
+
+## Test plan
+- [x] \`cd writer && vendor/bin/phpunit\` → \`OK (163 tests, 300 assertions)\` — unchanged
+- [x] \`cd writer-app && vendor/bin/phpunit\` → \`OK (70 tests, …)\` (58 A3.2 baseline + 12 new)
+- [x] Snapshot: \`writer-app/tests/Snapshots/open-tabs.html\` matches fixture
+- [x] Smoke: \`GET /api/reports/open-tabs\` returns 200 + HTML
+- [x] Predecessor reports still return 200 (daily-sales, sales-by-category)
+EOF
+)"
+```
+
+No `🤖 Generated with Claude Code` trailer. No `Co-Authored-By: Claude` trailer.
+
+- [ ] **Step 8: Post the PR link in `#report`**
+
+One line: `A3.3 open: <PR URL>. Docker mount free.`
+
+---
+
+## Rollback plan
+
+If Task 4 snapshot diverges or Task 6 curl returns non-200:
+
+1. Read the emitted HTML first. Compare against expected `Open Tabs`, `Order`, `Opened`, `Running Total`, `2000`, `2026-08-22 15:00`, `$5.00`.
+2. **No detail rows** → provider filter is inverted. Should be `closed_at IS NULL`, not `IS NOT NULL`.
+3. **Wrong Running Total ($.00 instead of $5.00)** → `format: "cents"` missing on the detail element, or the field name is misspelled (must match provider's `running_total_cents`).
+4. **Zero-item open tab missing** → provider uses INNER JOIN instead of LEFT JOIN, or missing `COALESCE`.
+5. **Ordering wrong** → SQL missing `ORDER BY o.opened_at ASC, o.id ASC`.
+6. **404 or 500 on the endpoint** → `open-tabs.filler` factory not registered, or `ReportDefinition` for `open-tabs` missing from `ReportRegistry`.
+7. `git reset --hard main` on the feature branch discards the whole thing — use only if the rewrite is smaller than the fix.
+
+## Self-review checklist (executed 2026-08-23 when this plan was written)
+
+- **Spec coverage:**
+  - "Uses the JsonTemplateRepository from A3.2" → Task 3 (registers `open-tabs.filler` service; reuses A3.2's repository and factory unchanged).
+  - "Data source: `SqliteOpenTabsProvider` — one row per `orders` row where `closed_at IS NULL`, with `order_id, opened_at, running_total_cents`" → Task 1.
+  - "Report: columns `Order | Opened | Running Total`; no grouping; no footer aggregate" → Task 2 (JSON), verified by Task 4 (snapshot has three columns + no summary band).
+  - "Param: none (or optional as_of timestamp; keep to none for simplicity)" → Task 1 explicitly ignores params; Task 2 omits the `params` block; Task 3 asserts `getParams() === []`.
+- **Placeholder scan:** none. All code, all commands, all expected outputs concrete.
+- **Type / name consistency:** service id `open-tabs.filler` used in Kernel (Task 3), ReportRegistry entry (Task 3), and wiring test (Task 3). Source name `open-tabs` used identically in the JSON template (Task 2), the registry registration (Task 3), the snapshot test setup (Task 4), and the wiring test. Provider class `SqliteOpenTabsProvider` consistent across File Structure, Tasks 1 + 3 + 4.
+- **Cross-plan consistency:** matches A3.2's wiring conventions (per-JSON-report `{id}.filler` service, shared DataSourceRegistry factory) so a reviewer can eyeball the two plans side-by-side and see the same pattern.
+- **Task cadence:** Tasks 1, 2, 3, 4, 5 each end in a commit. Task 6 pushes + opens the PR. Rollback maps failures back to specific tasks.

--- a/docs/superpowers/plans/2026-08-23-a3.3-open-tabs.md
+++ b/docs/superpowers/plans/2026-08-23-a3.3-open-tabs.md
@@ -751,9 +751,11 @@ Then:
 ```bash
 grep -c 'Open Tabs' /tmp/opentabs.html
 ```
-Expected: `1` or greater.
+Expected: `1` or greater — this matches the *title* text, not the row count.
 
-Note the row count is data-dependent — the demo seed produces many open tabs (see A3.1 seed output where "payments=1511 = # closed orders", implying `total_orders - 1511` open tabs). Do not pin an exact count in this step.
+**Expected row count: zero.** The A3.1 demo seed closes every order (`$closedTs = strtotime($opened) + $durMin * 60` in `seed.php`, no branch for open-ended orders). So `/api/reports/open-tabs` in the demo will render with the title + column headers + no detail rows. That's fine — the snapshot test against `coffee-shop-mini.sql` (which does contain one open tab) proves the report *works*; the demo just doesn't showcase it. A follow-up ticket should add a small tail of open tabs to the demo seed (with `SeedDeterminismTest` updates) — file that separately, out of scope for A3.3.
+
+Do NOT chase a non-empty demo result in this task. If you accidentally see one, either the seed changed or you're pointing at the fixture DB.
 
 - [ ] **Step 4: Verify predecessor reports still work**
 


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/plans/2026-08-23-a3.3-open-tabs.md` — the implementation plan for A3.3 of Sub-project A.
- 6 tasks, TDD-driven, docs-only in this PR. Sequenced after **A3.2** (already merged) because Task 3 reuses the `DataSourceRegistry`, `DefinitionFillerFactory`, `JsonTemplateRepository`, and `SnapshotAssertions` trait that A3.2 established.
- Intentionally lean: adds one provider, one JSON template, one line inside the existing `DataSourceRegistry` factory, one `{id}.filler` service, one `ReportDefinition` entry, and one snapshot test. No new infrastructure.
- Proves the A3.2 pattern generalizes to a differently-shaped report (no grouping, no summary, no params).

## Plan shape

- Task 0: baseline (blocks on A3.2 being merged — already done)
- Task 1: `SqliteOpenTabsProvider` (5 unit tests: `closed_at IS NULL` filter, param-ignored, ordering, empty case, zero-item open tab)
- Task 2: author `writer-app/templates/open-tabs.json` (no `params` block, no `summary` band)
- Task 3: wire `Kernel.php` — provider factory + `DataSourceRegistry` extension + `open-tabs.filler` service + `ReportDefinition` entry (5 wiring tests inc. regression guards for A3.1 + A3.2 registrations)
- Task 4: snapshot test — reuses `SnapshotAssertions` trait; snapshot pins order 2000 | 2026-08-22 15:00 | \$5.00
- Task 5: extend existing smoke test with `GET /api/reports/open-tabs`
- Task 6: verify library unchanged + demo curl (all three reports) + push + PR

## Design references

- Spec: `docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md` § A3.3
- Predecessor plan: `docs/superpowers/plans/2026-08-23-a3.2-sales-by-category.md`

## Test plan

- [x] Plan follows A3.2 conventions (same wiring shape, same snapshot trait) so a reviewer can eyeball both plans side-by-side
- [ ] Sibling agent peer review — ping in coordination channel post-open
- [ ] N/A — no code changes in this PR; the plan itself is the deliverable