### PR TITLE
feat(A3.2): Sales by Category report + JSON template infrastructure

### DIFF
--- a/writer-app/src/Kernel.php
+++ b/writer-app/src/Kernel.php
@@ -12,13 +12,20 @@ use ReportWriter\App\Http\JsonErrorHandler;
 use ReportWriter\App\Http\ReportController;
 use ReportWriter\App\Reports\DailySalesFiller;
 use ReportWriter\App\Reports\DataSource\SqliteDailySalesProvider;
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryProvider;
+use ReportWriter\App\Reports\JsonTemplateRepository;
 use ReportWriter\App\Reports\ParamSpec;
 use ReportWriter\App\Reports\ReportDefinition;
 use ReportWriter\App\Reports\ReportRegistry;
+use ReportWriter\Fill\DefinitionFiller;
+use ReportWriter\Fill\DefinitionFillerFactory;
 use ReportWriter\Layout\Flattener;
 use ReportWriter\Layout\LayoutService;
 use ReportWriter\Layout\PageConfig;
+use ReportWriter\Registry\DataSourceRegistry;
+use ReportWriter\Registry\FormatterRegistry;
 use ReportWriter\Renderer\HtmlRenderer;
+use ReportWriter\Template\TemplateLoader;
 use RuntimeException;
 use Slim\App;
 use Slim\Factory\AppFactory as SlimAppFactory;
@@ -67,11 +74,52 @@ final class Kernel
         $c->set(DailySalesFiller::class,
             static fn (Container $c) => new DailySalesFiller($c->get(SqliteDailySalesProvider::class)));
 
+        $c->set(SqliteSalesByCategoryProvider::class,
+            static fn (Container $c) => new SqliteSalesByCategoryProvider($c->get(PDO::class)));
+
+        $c->set(FormatterRegistry::class,
+            static fn () => FormatterRegistry::defaults());
+
+        $c->set(DataSourceRegistry::class, static function (Container $c): DataSourceRegistry {
+            $registry = new DataSourceRegistry();
+            $registry->register('sales-by-category', $c->get(SqliteSalesByCategoryProvider::class));
+            return $registry;
+        });
+
+        $c->set(DefinitionFillerFactory::class,
+            static fn (Container $c) => new DefinitionFillerFactory(
+                $c->get(DataSourceRegistry::class),
+                $c->get(FormatterRegistry::class)
+            ));
+
+        $c->set(TemplateLoader::class,
+            static fn () => new TemplateLoader());
+
+        $c->set(JsonTemplateRepository::class,
+            static fn (Container $c) => new JsonTemplateRepository(
+                __DIR__ . '/../templates',
+                $c->get(TemplateLoader::class)
+            ));
+
+        $c->set('sales-by-category.filler', static function (Container $c): DefinitionFiller {
+            /** @var JsonTemplateRepository $repo */
+            $repo = $c->get(JsonTemplateRepository::class);
+            /** @var DefinitionFillerFactory $factory */
+            $factory = $c->get(DefinitionFillerFactory::class);
+            return $factory->create($repo->load('sales-by-category'));
+        });
+
         $c->set(ReportRegistry::class, static fn () => new ReportRegistry([
             new ReportDefinition(
                 'daily-sales',
                 'Daily Sales',
                 DailySalesFiller::class,
+                [new ParamSpec('date', 'date', true)]
+            ),
+            new ReportDefinition(
+                'sales-by-category',
+                'Sales by Category',
+                'sales-by-category.filler',
                 [new ParamSpec('date', 'date', true)]
             ),
         ]));

--- a/writer-app/src/Reports/DataSource/SqliteSalesByCategoryProvider.php
+++ b/writer-app/src/Reports/DataSource/SqliteSalesByCategoryProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Reports\DataSource;
+
+use InvalidArgumentException;
+use PDO;
+use ReportWriter\Interfaces\ReportDataSourceInterface;
+
+final class SqliteSalesByCategoryProvider implements ReportDataSourceInterface
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * @param  array{date?: string} $params
+     * @return array<int, array{category_name: string, total_cents: int}>
+     */
+    public function fetchRows(array $params): array
+    {
+        $date = $params['date'] ?? null;
+        if (!is_string($date) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+            throw new InvalidArgumentException("Parameter 'date' must be YYYY-MM-DD; got " . var_export($date, true));
+        }
+
+        $sql = <<<SQL
+            SELECT
+                c.name                                        AS category_name,
+                SUM(oi.quantity * oi.unit_price_cents)        AS total_cents
+            FROM categories c
+            JOIN items       i  ON i.category_id = c.id
+            JOIN order_items oi ON oi.item_id    = i.id
+            JOIN orders      o  ON o.id          = oi.order_id
+            WHERE date(o.closed_at) = :date
+              AND o.closed_at IS NOT NULL
+            GROUP BY c.id, c.name
+            ORDER BY total_cents DESC, c.name ASC
+        SQL;
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['date' => $date]);
+
+        return array_map(
+            static fn (array $r): array => [
+                'category_name' => (string) $r['category_name'],
+                'total_cents'   => (int)    $r['total_cents'],
+            ],
+            $stmt->fetchAll()
+        );
+    }
+}

--- a/writer-app/src/Reports/JsonTemplateRepository.php
+++ b/writer-app/src/Reports/JsonTemplateRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Reports;
+
+use InvalidArgumentException;
+use ReportWriter\Template\ReportTemplate;
+use ReportWriter\Template\TemplateLoader;
+
+/**
+ * Loads JSON report templates from a fixed directory.
+ *
+ * Names are constrained to [a-z0-9_-]+ (no dots, no slashes, no absolute
+ * paths) so callers cannot escape the templates directory. Delegates the
+ * actual JSON parsing to the library's TemplateLoader.
+ */
+final class JsonTemplateRepository
+{
+    private string $templateDir;
+    private TemplateLoader $loader;
+
+    public function __construct(string $templateDir, TemplateLoader $loader)
+    {
+        $this->templateDir = rtrim($templateDir, '/');
+        $this->loader      = $loader;
+    }
+
+    public function load(string $name): ReportTemplate
+    {
+        if (preg_match('/^[a-z0-9_-]+$/', $name) !== 1) {
+            throw new InvalidArgumentException(
+                "Template name must match [a-z0-9_-]+; got " . var_export($name, true)
+            );
+        }
+        return $this->loader->load($this->templateDir . '/' . $name . '.json');
+    }
+}

--- a/writer-app/templates/sales-by-category.json
+++ b/writer-app/templates/sales-by-category.json
@@ -1,0 +1,68 @@
+{
+  "report_definition_id": "sales-by-category",
+  "data_source": "sales-by-category",
+  "params": {
+    "date": { "type": "date", "required": true }
+  },
+  "bands": [
+    {
+      "id": "title",
+      "type": "title",
+      "elements": [
+        {
+          "id": "title_text",
+          "x": 0, "width": 0, "height": 24, "align": "center",
+          "content": { "type": "text", "value": "Sales by Category — {date}" }
+        }
+      ]
+    },
+    {
+      "id": "col_header",
+      "type": "col-header",
+      "elements": [
+        {
+          "id": "hdr_category",
+          "x": 0, "width": 300, "height": 16, "align": "left",
+          "content": { "type": "text", "value": "Category" }
+        },
+        {
+          "id": "hdr_total",
+          "x": 300, "width": 180, "height": 16, "align": "right",
+          "content": { "type": "text", "value": "Total" }
+        }
+      ]
+    },
+    {
+      "id": "detail",
+      "type": "detail",
+      "elements": [
+        {
+          "id": "category",
+          "x": 0, "width": 300, "height": 14, "align": "left",
+          "content": { "type": "field", "field": "category_name" }
+        },
+        {
+          "id": "total",
+          "x": 300, "width": 180, "height": 14, "align": "right",
+          "content": { "type": "field", "field": "total_cents", "format": "cents" }
+        }
+      ]
+    },
+    {
+      "id": "summary",
+      "type": "summary",
+      "elements": [
+        {
+          "id": "grand_total_label",
+          "x": 0, "width": 300, "height": 16, "align": "right",
+          "content": { "type": "text", "value": "Grand Total" }
+        },
+        {
+          "id": "grand_total",
+          "x": 300, "width": 180, "height": 16, "align": "right",
+          "content": { "type": "aggregate", "field": "total_cents", "fn": "sum", "format": "cents" }
+        }
+      ]
+    }
+  ]
+}

--- a/writer-app/tests/Smoke/ReportRenderSmokeTest.php
+++ b/writer-app/tests/Smoke/ReportRenderSmokeTest.php
@@ -34,6 +34,22 @@ final class ReportRenderSmokeTest extends TestCase
         $this->assertStringContainsString('1003', $html, 'order id 1003 should appear in the rendered HTML');
     }
 
+    public function testSalesByCategoryRespondsWithHtml(): void
+    {
+        $pdo = DailySalesFixture::newPdo();
+
+        $app = AppFactory::buildTestApp(static function (Container $c) use ($pdo): void {
+            $c->set(PDO::class, static fn () => $pdo);
+        });
+
+        $request  = (new ServerRequestFactory())->createServerRequest('GET', '/api/reports/sales-by-category?date=2026-08-22');
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringStartsWith('text/html', $response->getHeaderLine('Content-Type'));
+        $this->assertStringContainsString('Sales by Category', (string) $response->getBody());
+    }
+
     public function testUnknownReportReturns404Json(): void
     {
         $pdo = DailySalesFixture::newPdo();

--- a/writer-app/tests/Snapshots/sales-by-category.html
+++ b/writer-app/tests/Snapshots/sales-by-category.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+body{margin:0;padding:20pt;background:#e0e0e0;font-family:sans-serif}
+.fu-page{position:relative;background:#fff;margin:0 auto 24pt;box-shadow:0 2px 8px rgba(0,0,0,.25);overflow:hidden}
+.fu-el{position:absolute;box-sizing:border-box;font-size:9pt;line-height:1.3;overflow:hidden;white-space:pre-wrap}
+.fu-band-overlay{position:absolute;left:0;width:100%;pointer-events:none;}
+.fu-band-title{font-size:14pt;font-weight:bold;text-align:center;color:#1a1a2e;}.fu-band-col-header{font-weight:bold;}.fu-band-group-header{font-weight:bold;color:#1a1a2e;}.fu-band-group-footer{font-style:italic;color:#555555;}.fu-band-summary{color:#555555;font-style:italic;}.fu-band-overlay-col-header{border-bottom:1px solid #333;}
+@media print{
+@page{margin:0}
+body{padding:0;background:none}
+.fu-page{margin:0;box-shadow:none;break-after:page;page-break-after:always}
+.fu-page:last-child{break-after:avoid;page-break-after:avoid}
+}
+</style>
+</head>
+<body>
+<div class="fu-page" style="width:612.00pt;height:792.00pt;" data-page="1"><div class="fu-el fu-band-title" style="left:20.00pt;top:20.00pt;width:572.00pt;height:24.00pt;text-align:center;">Sales by Category — 2026-08-22</div><div class="fu-el fu-band-col-header" style="left:20.00pt;top:44.00pt;width:300.00pt;height:16.00pt;text-align:left;">Category</div><div class="fu-el fu-band-col-header" style="left:320.00pt;top:44.00pt;width:180.00pt;height:16.00pt;text-align:right;">Total</div><div class="fu-el fu-band-detail" style="left:20.00pt;top:60.00pt;width:300.00pt;height:14.00pt;text-align:left;">Coffee</div><div class="fu-el fu-band-detail" style="left:320.00pt;top:60.00pt;width:180.00pt;height:14.00pt;text-align:right;">$22.00</div><div class="fu-el fu-band-detail" style="left:20.00pt;top:74.00pt;width:300.00pt;height:14.00pt;text-align:left;">Pastry</div><div class="fu-el fu-band-detail" style="left:320.00pt;top:74.00pt;width:180.00pt;height:14.00pt;text-align:right;">$7.50</div><div class="fu-el fu-band-summary" style="left:20.00pt;top:88.00pt;width:300.00pt;height:16.00pt;text-align:right;">Grand Total</div><div class="fu-el fu-band-summary" style="left:320.00pt;top:88.00pt;width:180.00pt;height:16.00pt;text-align:right;">$29.50</div><div class="fu-band-overlay fu-band-overlay-col-header" style="top:44.00pt;height:16.00pt;"></div></div></body>
+</html>

--- a/writer-app/tests/Support/SnapshotAssertions.php
+++ b/writer-app/tests/Support/SnapshotAssertions.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Support;
+
+use PHPUnit\Framework\Assert;
+
+/**
+ * assertSnapshotMatches($actual, $snapshotPath):
+ *   - If the snapshot file is missing, writes $actual and fails with a
+ *     "snapshot bootstrapped" message so the run is not silently green.
+ *   - If UPDATE_SNAPSHOTS=1 is set in the environment, overwrites the snapshot
+ *     with $actual and passes.
+ *   - Otherwise diffs $actual against the file contents byte-for-byte.
+ *
+ * Reused by A3.2 (this ticket), A3.3 (Open Tabs), A3.5 (Register Close).
+ */
+trait SnapshotAssertions
+{
+    private function assertSnapshotMatches(string $actual, string $snapshotPath): void
+    {
+        $update = getenv('UPDATE_SNAPSHOTS') === '1';
+
+        if (!file_exists($snapshotPath) || $update) {
+            $dir = dirname($snapshotPath);
+            if (!is_dir($dir)) {
+                mkdir($dir, 0777, true);
+            }
+            file_put_contents($snapshotPath, $actual);
+            if (!$update) {
+                Assert::fail("Snapshot bootstrapped at {$snapshotPath}. Re-run the test to verify.");
+            }
+            return;
+        }
+
+        Assert::assertSame(
+            (string) file_get_contents($snapshotPath),
+            $actual,
+            "Snapshot mismatch at {$snapshotPath}. Re-run with UPDATE_SNAPSHOTS=1 to accept."
+        );
+    }
+}

--- a/writer-app/tests/Unit/ContainerA32WiringTest.php
+++ b/writer-app/tests/Unit/ContainerA32WiringTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Config;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Kernel;
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryProvider;
+use ReportWriter\App\Reports\JsonTemplateRepository;
+use ReportWriter\App\Reports\ReportRegistry;
+use ReportWriter\Fill\DefinitionFiller;
+use ReportWriter\Fill\DefinitionFillerFactory;
+use ReportWriter\Registry\DataSourceRegistry;
+use ReportWriter\Registry\FormatterRegistry;
+
+final class ContainerA32WiringTest extends TestCase
+{
+    private function container(): \ReportWriter\App\Container
+    {
+        $c = Kernel::defaultContainer(new Config(':memory:', false));
+        $c->set(PDO::class, static fn () => SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../database/schema.sql'
+        ));
+        return $c;
+    }
+
+    public function testDataSourceRegistryIsShared(): void
+    {
+        $c = $this->container();
+        $r1 = $c->get(DataSourceRegistry::class);
+        $r2 = $c->get(DataSourceRegistry::class);
+        $this->assertSame($r1, $r2, 'DataSourceRegistry must be a singleton');
+        $this->assertInstanceOf(DataSourceRegistry::class, $r1);
+    }
+
+    public function testDataSourceRegistryContainsSalesByCategorySource(): void
+    {
+        $registry = $this->container()->get(DataSourceRegistry::class);
+        $this->assertTrue($registry->has('sales-by-category'));
+        $this->assertInstanceOf(SqliteSalesByCategoryProvider::class, $registry->get('sales-by-category'));
+    }
+
+    public function testFormatterRegistryIsResolvableAndProvidesCentsFormatter(): void
+    {
+        $formatters = $this->container()->get(FormatterRegistry::class);
+        $this->assertInstanceOf(FormatterRegistry::class, $formatters);
+        $format = $formatters->get('cents');
+        $this->assertSame('$1.23', $format(123));
+    }
+
+    public function testDefinitionFillerFactoryIsResolvable(): void
+    {
+        $factory = $this->container()->get(DefinitionFillerFactory::class);
+        $this->assertInstanceOf(DefinitionFillerFactory::class, $factory);
+    }
+
+    public function testJsonTemplateRepositoryPointsAtTemplatesDir(): void
+    {
+        $repo = $this->container()->get(JsonTemplateRepository::class);
+        $this->assertInstanceOf(JsonTemplateRepository::class, $repo);
+        $tmpl = $repo->load('sales-by-category');
+        $this->assertSame('sales-by-category', $tmpl->getReportDefinitionId());
+    }
+
+    public function testSalesByCategoryFillerServiceReturnsADefinitionFiller(): void
+    {
+        $filler = $this->container()->get('sales-by-category.filler');
+        $this->assertInstanceOf(DefinitionFiller::class, $filler);
+    }
+
+    public function testReportRegistryExposesSalesByCategoryDefinition(): void
+    {
+        $registry = $this->container()->get(ReportRegistry::class);
+        $def = $registry->get('sales-by-category');
+        $this->assertSame('sales-by-category', $def->getId());
+        $this->assertSame('Sales by Category', $def->getLabel());
+        $this->assertSame('sales-by-category.filler', $def->getFillerServiceId());
+        $params = $def->getParams();
+        $this->assertCount(1, $params);
+        $this->assertSame('date', $params[0]->getName());
+        $this->assertTrue($params[0]->isRequired());
+    }
+}

--- a/writer-app/tests/Unit/Reports/DataSource/SqliteSalesByCategoryProviderTest.php
+++ b/writer-app/tests/Unit/Reports/DataSource/SqliteSalesByCategoryProviderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports\DataSource;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryProvider;
+
+final class SqliteSalesByCategoryProviderTest extends TestCase
+{
+    private const FIXTURE = __DIR__ . '/../../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA  = __DIR__ . '/../../../../database/schema.sql';
+
+    public function testFetchRowsReturnsCategoryTotalsOrderedByTotalDesc(): void
+    {
+        $rows = $this->fetch(['date' => '2026-08-22']);
+
+        $this->assertSame(
+            [
+                ['category_name' => 'Coffee', 'total_cents' => 2200],
+                ['category_name' => 'Pastry', 'total_cents' => 750],
+            ],
+            $rows
+        );
+    }
+
+    public function testFetchRowsExcludesOtherDates(): void
+    {
+        $rows = $this->fetch(['date' => '2026-08-22']);
+        $coffeeTotal = 0;
+        foreach ($rows as $row) {
+            if ($row['category_name'] === 'Coffee') {
+                $coffeeTotal = $row['total_cents'];
+            }
+        }
+        $this->assertSame(2200, $coffeeTotal, 'prior-day latte must not roll into 2026-08-22 Coffee total');
+    }
+
+    public function testFetchRowsExcludesOpenTabs(): void
+    {
+        $rows = $this->fetch(['date' => '2026-08-22']);
+        $coffeeTotal = 0;
+        foreach ($rows as $row) {
+            if ($row['category_name'] === 'Coffee') {
+                $coffeeTotal = $row['total_cents'];
+            }
+        }
+        $this->assertSame(2200, $coffeeTotal, 'open-tab items must not roll into any total');
+    }
+
+    public function testFetchRowsReturnsEmptyForDateWithNoClosedOrders(): void
+    {
+        $this->assertSame([], $this->fetch(['date' => '2020-01-01']));
+    }
+
+    public function testFetchRowsRejectsMalformedDate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->fetch(['date' => 'yesterday']);
+    }
+
+    public function testFetchRowsRejectsMissingDate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->fetch([]);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<int, array{category_name: string, total_cents: int}>
+     */
+    private function fetch(array $params): array
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+        return (new SqliteSalesByCategoryProvider($pdo))->fetchRows($params);
+    }
+}

--- a/writer-app/tests/Unit/Reports/JsonTemplateRepositoryTest.php
+++ b/writer-app/tests/Unit/Reports/JsonTemplateRepositoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Reports\JsonTemplateRepository;
+use ReportWriter\Template\ReportTemplate;
+use ReportWriter\Template\TemplateLoader;
+
+final class JsonTemplateRepositoryTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/rw-json-repo-' . bin2hex(random_bytes(4));
+        mkdir($this->tmpDir);
+        file_put_contents(
+            $this->tmpDir . '/hello.json',
+            json_encode([
+                'report_definition_id' => 'hello',
+                'data_source'          => 'noop',
+                'bands'                => [],
+            ], JSON_THROW_ON_ERROR)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmpDir . '/*') ?: [] as $f) {
+            unlink($f);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    public function testLoadReturnsReportTemplateForKnownName(): void
+    {
+        $repo = new JsonTemplateRepository($this->tmpDir, new TemplateLoader());
+        $tmpl = $repo->load('hello');
+        $this->assertInstanceOf(ReportTemplate::class, $tmpl);
+        $this->assertSame('hello', $tmpl->getReportDefinitionId());
+    }
+
+    public function testLoadRejectsPathTraversal(): void
+    {
+        $repo = new JsonTemplateRepository($this->tmpDir, new TemplateLoader());
+        $this->expectException(InvalidArgumentException::class);
+        $repo->load('../evil');
+    }
+
+    public function testLoadRejectsAbsolutePath(): void
+    {
+        $repo = new JsonTemplateRepository($this->tmpDir, new TemplateLoader());
+        $this->expectException(InvalidArgumentException::class);
+        $repo->load('/etc/passwd');
+    }
+
+    public function testLoadRejectsDotSegment(): void
+    {
+        $repo = new JsonTemplateRepository($this->tmpDir, new TemplateLoader());
+        $this->expectException(InvalidArgumentException::class);
+        $repo->load('foo.bar');
+    }
+
+    public function testLoadThrowsForUnknownName(): void
+    {
+        $repo = new JsonTemplateRepository($this->tmpDir, new TemplateLoader());
+        $this->expectException(InvalidArgumentException::class);
+        $repo->load('does-not-exist');
+    }
+}

--- a/writer-app/tests/Unit/Reports/SalesByCategorySnapshotTest.php
+++ b/writer-app/tests/Unit/Reports/SalesByCategorySnapshotTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryProvider;
+use ReportWriter\App\Reports\JsonTemplateRepository;
+use ReportWriter\App\Tests\Support\SnapshotAssertions;
+use ReportWriter\Fill\DefinitionFillerFactory;
+use ReportWriter\Layout\Flattener;
+use ReportWriter\Layout\LayoutService;
+use ReportWriter\Layout\PageConfig;
+use ReportWriter\Registry\DataSourceRegistry;
+use ReportWriter\Registry\FormatterRegistry;
+use ReportWriter\Renderer\HtmlRenderer;
+use ReportWriter\Template\TemplateLoader;
+
+final class SalesByCategorySnapshotTest extends TestCase
+{
+    use SnapshotAssertions;
+
+    private const FIXTURE       = __DIR__ . '/../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA        = __DIR__ . '/../../../database/schema.sql';
+    private const TEMPLATES_DIR = __DIR__ . '/../../../templates';
+    private const SNAPSHOT      = __DIR__ . '/../../Snapshots/sales-by-category.html';
+
+    public function testRendersByteForByteMatchOfSnapshotOnFixture(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+
+        $registry = new DataSourceRegistry();
+        $registry->register('sales-by-category', new SqliteSalesByCategoryProvider($pdo));
+
+        $factory = new DefinitionFillerFactory($registry, FormatterRegistry::defaults());
+        $repo    = new JsonTemplateRepository(self::TEMPLATES_DIR, new TemplateLoader());
+
+        $filler   = $factory->create($repo->load('sales-by-category'));
+        $instance = $filler->fill(['date' => '2026-08-22']);
+
+        $page   = new PageConfig();
+        $stream = (new LayoutService(new Flattener(), $page))->layout($instance);
+        $html   = (new HtmlRenderer($page))->render($stream);
+
+        $this->assertSnapshotMatches($html, self::SNAPSHOT);
+    }
+}


### PR DESCRIPTION
## Summary
- **New report:** `GET /api/reports/sales-by-category?date=YYYY-MM-DD` — category totals for a given day, ordered by total descending, grand-total footer.
- **Infrastructure landed for reuse (A3.3, A3.5):**
  - `SqliteSalesByCategoryProvider` — new `ReportDataSourceInterface` implementation.
  - `JsonTemplateRepository` — loads named JSON templates from a fixed directory with name whitelisting (`[a-z0-9_-]+`).
  - `Kernel.php` wires `DataSourceRegistry` + `FormatterRegistry` + `DefinitionFillerFactory` + `JsonTemplateRepository`. Per-JSON-report filler services register as `{id}.filler` and resolve to a `DefinitionFiller` instance.
  - `writer-app/templates/sales-by-category.json` — first template.
  - `SnapshotAssertions` trait — reusable byte-for-byte HTML snapshot helper (`UPDATE_SNAPSHOTS=1` refresh).
- Daily Sales pathway untouched (constructor-injected provider, no registry).

Design: `docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md` § A3.2.
Plan:   `docs/superpowers/plans/2026-08-23-a3.2-sales-by-category.md`.

## Test plan
- [x] `cd writer && vendor/bin/phpunit` → `OK (163 tests, 300 assertions)` — unchanged
- [x] `cd writer-app && vendor/bin/phpunit` → `OK (58 tests, 117 assertions)` (38 A3.1 baseline + 20 new)
- [x] Snapshot: `writer-app/tests/Snapshots/sales-by-category.html` matches fixture; automated content check (9 tokens including `$22.00`, `$7.50`, `$29.50`)
- [x] Smoke: `GET /api/reports/sales-by-category?date=2026-08-22` returns 200 + `text/html`
- [x] Daily Sales still returns 200 (regression check on the wiring change)