### PR TITLE
feat(A3.3): Open Tabs report

### DIFF
--- a/writer-app/src/Kernel.php
+++ b/writer-app/src/Kernel.php
@@ -12,6 +12,7 @@ use ReportWriter\App\Http\JsonErrorHandler;
 use ReportWriter\App\Http\ReportController;
 use ReportWriter\App\Reports\DailySalesFiller;
 use ReportWriter\App\Reports\DataSource\SqliteDailySalesProvider;
+use ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider;
 use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryProvider;
 use ReportWriter\App\Reports\JsonTemplateRepository;
 use ReportWriter\App\Reports\ParamSpec;
@@ -77,12 +78,16 @@ final class Kernel
         $c->set(SqliteSalesByCategoryProvider::class,
             static fn (Container $c) => new SqliteSalesByCategoryProvider($c->get(PDO::class)));
 
+        $c->set(SqliteOpenTabsProvider::class,
+            static fn (Container $c) => new SqliteOpenTabsProvider($c->get(PDO::class)));
+
         $c->set(FormatterRegistry::class,
             static fn () => FormatterRegistry::defaults());
 
         $c->set(DataSourceRegistry::class, static function (Container $c): DataSourceRegistry {
             $registry = new DataSourceRegistry();
             $registry->register('sales-by-category', $c->get(SqliteSalesByCategoryProvider::class));
+            $registry->register('open-tabs',         $c->get(SqliteOpenTabsProvider::class));
             return $registry;
         });
 
@@ -109,6 +114,14 @@ final class Kernel
             return $factory->create($repo->load('sales-by-category'));
         });
 
+        $c->set('open-tabs.filler', static function (Container $c): DefinitionFiller {
+            /** @var JsonTemplateRepository $repo */
+            $repo = $c->get(JsonTemplateRepository::class);
+            /** @var DefinitionFillerFactory $factory */
+            $factory = $c->get(DefinitionFillerFactory::class);
+            return $factory->create($repo->load('open-tabs'));
+        });
+
         $c->set(ReportRegistry::class, static fn () => new ReportRegistry([
             new ReportDefinition(
                 'daily-sales',
@@ -121,6 +134,12 @@ final class Kernel
                 'Sales by Category',
                 'sales-by-category.filler',
                 [new ParamSpec('date', 'date', true)]
+            ),
+            new ReportDefinition(
+                'open-tabs',
+                'Open Tabs',
+                'open-tabs.filler',
+                []
             ),
         ]));
 

--- a/writer-app/src/Reports/DataSource/SqliteOpenTabsProvider.php
+++ b/writer-app/src/Reports/DataSource/SqliteOpenTabsProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Reports\DataSource;
+
+use PDO;
+use ReportWriter\Interfaces\ReportDataSourceInterface;
+
+final class SqliteOpenTabsProvider implements ReportDataSourceInterface
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * A3.3 is param-less; $params is ignored.
+     *
+     * @param  array<string, mixed> $params
+     * @return array<int, array{order_id: int, opened_at: string, running_total_cents: int}>
+     */
+    public function fetchRows(array $params): array
+    {
+        $sql = <<<SQL
+            SELECT
+                o.id                                                       AS order_id,
+                strftime('%Y-%m-%d %H:%M', o.opened_at)                    AS opened_at,
+                COALESCE(SUM(oi.quantity * oi.unit_price_cents), 0)        AS running_total_cents
+            FROM orders o
+            LEFT JOIN order_items oi ON oi.order_id = o.id
+            WHERE o.closed_at IS NULL
+            GROUP BY o.id, o.opened_at
+            ORDER BY o.opened_at ASC, o.id ASC
+        SQL;
+
+        $stmt = $this->pdo->query($sql);
+
+        return array_map(
+            static fn (array $r): array => [
+                'order_id'            => (int)    $r['order_id'],
+                'opened_at'           => (string) $r['opened_at'],
+                'running_total_cents' => (int)    $r['running_total_cents'],
+            ],
+            $stmt->fetchAll()
+        );
+    }
+}

--- a/writer-app/templates/open-tabs.json
+++ b/writer-app/templates/open-tabs.json
@@ -1,0 +1,59 @@
+{
+  "report_definition_id": "open-tabs",
+  "data_source": "open-tabs",
+  "bands": [
+    {
+      "id": "title",
+      "type": "title",
+      "elements": [
+        {
+          "id": "title_text",
+          "x": 0, "width": 0, "height": 24, "align": "center",
+          "content": { "type": "text", "value": "Open Tabs" }
+        }
+      ]
+    },
+    {
+      "id": "col_header",
+      "type": "col-header",
+      "elements": [
+        {
+          "id": "hdr_order",
+          "x": 0, "width": 120, "height": 16, "align": "left",
+          "content": { "type": "text", "value": "Order" }
+        },
+        {
+          "id": "hdr_opened",
+          "x": 120, "width": 200, "height": 16, "align": "left",
+          "content": { "type": "text", "value": "Opened" }
+        },
+        {
+          "id": "hdr_running_total",
+          "x": 320, "width": 160, "height": 16, "align": "right",
+          "content": { "type": "text", "value": "Running Total" }
+        }
+      ]
+    },
+    {
+      "id": "detail",
+      "type": "detail",
+      "elements": [
+        {
+          "id": "order_id",
+          "x": 0, "width": 120, "height": 14, "align": "left",
+          "content": { "type": "field", "field": "order_id" }
+        },
+        {
+          "id": "opened_at",
+          "x": 120, "width": 200, "height": 14, "align": "left",
+          "content": { "type": "field", "field": "opened_at" }
+        },
+        {
+          "id": "running_total",
+          "x": 320, "width": 160, "height": 14, "align": "right",
+          "content": { "type": "field", "field": "running_total_cents", "format": "cents" }
+        }
+      ]
+    }
+  ]
+}

--- a/writer-app/tests/Smoke/ReportRenderSmokeTest.php
+++ b/writer-app/tests/Smoke/ReportRenderSmokeTest.php
@@ -50,6 +50,22 @@ final class ReportRenderSmokeTest extends TestCase
         $this->assertStringContainsString('Sales by Category', (string) $response->getBody());
     }
 
+    public function testOpenTabsRespondsWithHtml(): void
+    {
+        $pdo = DailySalesFixture::newPdo();
+
+        $app = AppFactory::buildTestApp(static function (Container $c) use ($pdo): void {
+            $c->set(PDO::class, static fn () => $pdo);
+        });
+
+        $request  = (new ServerRequestFactory())->createServerRequest('GET', '/api/reports/open-tabs');
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringStartsWith('text/html', $response->getHeaderLine('Content-Type'));
+        $this->assertStringContainsString('Open Tabs', (string) $response->getBody());
+    }
+
     public function testUnknownReportReturns404Json(): void
     {
         $pdo = DailySalesFixture::newPdo();

--- a/writer-app/tests/Snapshots/open-tabs.html
+++ b/writer-app/tests/Snapshots/open-tabs.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+body{margin:0;padding:20pt;background:#e0e0e0;font-family:sans-serif}
+.fu-page{position:relative;background:#fff;margin:0 auto 24pt;box-shadow:0 2px 8px rgba(0,0,0,.25);overflow:hidden}
+.fu-el{position:absolute;box-sizing:border-box;font-size:9pt;line-height:1.3;overflow:hidden;white-space:pre-wrap}
+.fu-band-overlay{position:absolute;left:0;width:100%;pointer-events:none;}
+.fu-band-title{font-size:14pt;font-weight:bold;text-align:center;color:#1a1a2e;}.fu-band-col-header{font-weight:bold;}.fu-band-group-header{font-weight:bold;color:#1a1a2e;}.fu-band-group-footer{font-style:italic;color:#555555;}.fu-band-summary{color:#555555;font-style:italic;}.fu-band-overlay-col-header{border-bottom:1px solid #333;}
+@media print{
+@page{margin:0}
+body{padding:0;background:none}
+.fu-page{margin:0;box-shadow:none;break-after:page;page-break-after:always}
+.fu-page:last-child{break-after:avoid;page-break-after:avoid}
+}
+</style>
+</head>
+<body>
+<div class="fu-page" style="width:612.00pt;height:792.00pt;" data-page="1"><div class="fu-el fu-band-title" style="left:20.00pt;top:20.00pt;width:572.00pt;height:24.00pt;text-align:center;">Open Tabs</div><div class="fu-el fu-band-col-header" style="left:20.00pt;top:44.00pt;width:120.00pt;height:16.00pt;text-align:left;">Order</div><div class="fu-el fu-band-col-header" style="left:140.00pt;top:44.00pt;width:200.00pt;height:16.00pt;text-align:left;">Opened</div><div class="fu-el fu-band-col-header" style="left:340.00pt;top:44.00pt;width:160.00pt;height:16.00pt;text-align:right;">Running Total</div><div class="fu-el fu-band-detail" style="left:20.00pt;top:60.00pt;width:120.00pt;height:14.00pt;text-align:left;">2000</div><div class="fu-el fu-band-detail" style="left:140.00pt;top:60.00pt;width:200.00pt;height:14.00pt;text-align:left;">2026-08-22 15:00</div><div class="fu-el fu-band-detail" style="left:340.00pt;top:60.00pt;width:160.00pt;height:14.00pt;text-align:right;">$5.00</div><div class="fu-band-overlay fu-band-overlay-col-header" style="top:44.00pt;height:16.00pt;"></div></div></body>
+</html>

--- a/writer-app/tests/Unit/ContainerA33WiringTest.php
+++ b/writer-app/tests/Unit/ContainerA33WiringTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Config;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Kernel;
+use ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider;
+use ReportWriter\App\Reports\ReportRegistry;
+use ReportWriter\Fill\DefinitionFiller;
+use ReportWriter\Registry\DataSourceRegistry;
+
+final class ContainerA33WiringTest extends TestCase
+{
+    private function container(): \ReportWriter\App\Container
+    {
+        $c = Kernel::defaultContainer(new Config(':memory:', false));
+        $c->set(PDO::class, static fn () => SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../database/schema.sql'
+        ));
+        return $c;
+    }
+
+    public function testDataSourceRegistryContainsOpenTabsSource(): void
+    {
+        $registry = $this->container()->get(DataSourceRegistry::class);
+        $this->assertTrue($registry->has('open-tabs'));
+        $this->assertInstanceOf(SqliteOpenTabsProvider::class, $registry->get('open-tabs'));
+    }
+
+    public function testDataSourceRegistryStillContainsSalesByCategorySource(): void
+    {
+        $registry = $this->container()->get(DataSourceRegistry::class);
+        $this->assertTrue($registry->has('sales-by-category'));
+    }
+
+    public function testOpenTabsFillerServiceReturnsADefinitionFiller(): void
+    {
+        $filler = $this->container()->get('open-tabs.filler');
+        $this->assertInstanceOf(DefinitionFiller::class, $filler);
+    }
+
+    public function testReportRegistryExposesOpenTabsDefinition(): void
+    {
+        $registry = $this->container()->get(ReportRegistry::class);
+        $def = $registry->get('open-tabs');
+        $this->assertSame('open-tabs', $def->getId());
+        $this->assertSame('Open Tabs', $def->getLabel());
+        $this->assertSame('open-tabs.filler', $def->getFillerServiceId());
+        $this->assertSame([], $def->getParams(), 'A3.3 is param-less');
+    }
+
+    public function testReportRegistryStillExposesPredecessorReports(): void
+    {
+        $registry = $this->container()->get(ReportRegistry::class);
+        $this->assertSame('daily-sales',       $registry->get('daily-sales')->getId());
+        $this->assertSame('sales-by-category', $registry->get('sales-by-category')->getId());
+    }
+}

--- a/writer-app/tests/Unit/Reports/DataSource/SqliteOpenTabsProviderTest.php
+++ b/writer-app/tests/Unit/Reports/DataSource/SqliteOpenTabsProviderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports\DataSource;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider;
+
+final class SqliteOpenTabsProviderTest extends TestCase
+{
+    private const FIXTURE = __DIR__ . '/../../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA  = __DIR__ . '/../../../../database/schema.sql';
+
+    public function testFetchRowsReturnsOnlyOrdersWithClosedAtNull(): void
+    {
+        $rows = $this->fetch();
+
+        $this->assertSame(
+            [
+                [
+                    'order_id'            => 2000,
+                    'opened_at'           => '2026-08-22 15:00',
+                    'running_total_cents' => 500,
+                ],
+            ],
+            $rows
+        );
+    }
+
+    public function testFetchRowsIgnoresParams(): void
+    {
+        $this->assertSame(
+            $this->fetch(),
+            (new SqliteOpenTabsProvider($this->seededPdo()))->fetchRows(['date' => '2026-08-22', 'garbage' => 'x'])
+        );
+    }
+
+    public function testFetchRowsOrdersByOpenedAtAscending(): void
+    {
+        $pdo = $this->seededPdo();
+        $pdo->exec("INSERT INTO orders (id, opened_at, closed_at)
+                    VALUES (2001, '2026-08-22T08:30:00Z', NULL)");
+        $pdo->exec("INSERT INTO order_items (id, order_id, item_id, quantity, unit_price_cents)
+                    VALUES (201, 2001, 2, 1, 600)");
+
+        $rows = (new SqliteOpenTabsProvider($pdo))->fetchRows([]);
+        $orderIds = array_column($rows, 'order_id');
+        $this->assertSame([2001, 2000], $orderIds, 'earlier opened_at must appear first');
+    }
+
+    public function testFetchRowsReturnsEmptyWhenNoOpenTabsExist(): void
+    {
+        $pdo = $this->seededPdo();
+        $pdo->exec("UPDATE orders SET closed_at = '2026-08-22T15:05:00Z' WHERE id = 2000");
+        $this->assertSame([], (new SqliteOpenTabsProvider($pdo))->fetchRows([]));
+    }
+
+    public function testFetchRowsHandlesOpenTabWithZeroItems(): void
+    {
+        $pdo = $this->seededPdo();
+        $pdo->exec("INSERT INTO orders (id, opened_at, closed_at)
+                    VALUES (2002, '2026-08-22T16:00:00Z', NULL)");
+
+        $rows = (new SqliteOpenTabsProvider($pdo))->fetchRows([]);
+        $totals = [];
+        foreach ($rows as $r) {
+            $totals[$r['order_id']] = $r['running_total_cents'];
+        }
+        $this->assertSame(0, $totals[2002] ?? null, 'zero-item open tab must have 0 running total');
+    }
+
+    /**
+     * @return array<int, array{order_id: int, opened_at: string, running_total_cents: int}>
+     */
+    private function fetch(): array
+    {
+        return (new SqliteOpenTabsProvider($this->seededPdo()))->fetchRows([]);
+    }
+
+    private function seededPdo(): \PDO
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+        return $pdo;
+    }
+}

--- a/writer-app/tests/Unit/Reports/OpenTabsSnapshotTest.php
+++ b/writer-app/tests/Unit/Reports/OpenTabsSnapshotTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteOpenTabsProvider;
+use ReportWriter\App\Reports\JsonTemplateRepository;
+use ReportWriter\App\Tests\Support\SnapshotAssertions;
+use ReportWriter\Fill\DefinitionFillerFactory;
+use ReportWriter\Layout\Flattener;
+use ReportWriter\Layout\LayoutService;
+use ReportWriter\Layout\PageConfig;
+use ReportWriter\Registry\DataSourceRegistry;
+use ReportWriter\Registry\FormatterRegistry;
+use ReportWriter\Renderer\HtmlRenderer;
+use ReportWriter\Template\TemplateLoader;
+
+final class OpenTabsSnapshotTest extends TestCase
+{
+    use SnapshotAssertions;
+
+    private const FIXTURE       = __DIR__ . '/../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA        = __DIR__ . '/../../../database/schema.sql';
+    private const TEMPLATES_DIR = __DIR__ . '/../../../templates';
+    private const SNAPSHOT      = __DIR__ . '/../../Snapshots/open-tabs.html';
+
+    public function testRendersByteForByteMatchOfSnapshotOnFixture(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+
+        $registry = new DataSourceRegistry();
+        $registry->register('open-tabs', new SqliteOpenTabsProvider($pdo));
+
+        $factory = new DefinitionFillerFactory($registry, FormatterRegistry::defaults());
+        $repo    = new JsonTemplateRepository(self::TEMPLATES_DIR, new TemplateLoader());
+
+        $filler   = $factory->create($repo->load('open-tabs'));
+        $instance = $filler->fill([]);
+
+        $page   = new PageConfig();
+        $stream = (new LayoutService(new Flattener(), $page))->layout($instance);
+        $html   = (new HtmlRenderer($page))->render($stream);
+
+        $this->assertSnapshotMatches($html, self::SNAPSHOT);
+    }
+}


### PR DESCRIPTION
## Summary
- **New report:** `GET /api/reports/open-tabs` — one row per order with `closed_at IS NULL`, ordered by `opened_at ASC`. No params, no grouping, no footer aggregate.
- **New provider:** `SqliteOpenTabsProvider` returns `{order_id, opened_at, running_total_cents}`. LEFT JOIN + `COALESCE` so open tabs with zero items still appear with 0 running total.
- **Reuses A3.2 infrastructure:** `JsonTemplateRepository`, `DataSourceRegistry`, `DefinitionFillerFactory`, `SnapshotAssertions` trait — all landed by A3.2. This PR adds one provider factory, one `register()` call, one `{id}.filler` service, and one `ReportDefinition`.
- Snapshot pinned against A3.1's `coffee-shop-mini.sql` fixture: order 2000 | 2026-08-22 15:00 | $5.00.
- **Known limitation:** demo seed produces zero open tabs (every seeded order gets a `closed_at`), so `/api/reports/open-tabs` renders empty rows in the running demo. Report correctness is verified by the snapshot test against the fixture. Follow-up in **PR #23 (Ticket 021)** to add an open-tabs tail to the seed.

Design: `docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md` § A3.3.
Plan:   `docs/superpowers/plans/2026-08-23-a3.3-open-tabs.md`.

## Test plan
- [x] `cd writer && vendor/bin/phpunit` → `OK (163 tests, 300 assertions)` — unchanged
- [x] `cd writer-app && vendor/bin/phpunit` → `OK (70 tests, 136 assertions)` (58 A3.2 baseline + 12 new: 5 provider + 5 wiring + 1 snapshot + 1 smoke)
- [x] Snapshot: `writer-app/tests/Snapshots/open-tabs.html` matches fixture; automated 7-token grep check (`Open Tabs`, `Order`, `Opened`, `Running Total`, `2000`, `2026-08-22 15:00`, `$5.00`)
- [x] Smoke: `GET /api/reports/open-tabs` returns 200 + `text/html`
- [x] Predecessor reports still work: `/api/reports/daily-sales?date=2026-08-22` = 200, `/api/reports/sales-by-category?date=2026-08-22` = 200

## Deviations from the plan (minor)
1. Task 6 Step 4 for-loop had `daily-sales` (no date) alongside `sales-by-category?date=…` — expected 200 across the board but daily-sales correctly returns 400 without its required date param. Re-ran with `?date=2026-08-22` to confirm 200. Not a regression; plan expectation was off.