### PR TITLE
docs(plans): A3.4 Sales by Category → Item implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-08-23-a3.4-sales-by-category-item.md
+++ b/docs/superpowers/plans/2026-08-23-a3.4-sales-by-category-item.md
@@ -1,0 +1,884 @@
+# A3.4 — Sales by Category → Item Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the "Sales by Category → Item" report as the first `ReportBuilder`-based sample report in A3. Establishes the code-first (not JSON-templated) filler pattern for reports that need per-group subtotals + a grand total, following the shape of the existing `DailySalesFiller`.
+
+**Architecture:** New `SqliteSalesByCategoryItemProvider` returns `{category_name, item_name, quantity_sold, total_cents}` — one row per `(category, item)` tuple aggregated across all orders on a given `date`. New `SalesByCategoryItemFiller implements ReportFillerInterface` wraps `ReportBuilder::create(...)->title(...)->columns([...])->rows($rows)->groupBy('category_name')->build()`. `Column::sum()` on Qty and Total installs an `AggregateExpression` on **both** the footer and summary expressions, so per-category subtotals and the grand total both come from the same shortcut. Filler is registered under its class name in `Kernel.php` (same convention as `DailySalesFiller`); no `DataSourceRegistry` involvement — that infrastructure is `DefinitionFiller`-only.
+
+**Tech Stack:** PHP 7.4+, PDO-SQLite, PHPUnit 9.5, Slim 4 (routing untouched). No frontend changes. No library (`writer/`) changes.
+
+**Design decision (surfaced early because it's load-bearing):**
+
+The A3 spec calls A3.4 "two-level groups" and cites the `ReportBuilder` rationale as "any report that needs nested groups must use ReportBuilder." This plan implements **one grouping level** (by `category_name`), with items as detail rows. Reasoning:
+
+- Data granularity is one row per `(category, item)` tuple (per the spec's own field list). A `groupBy('category_name', 'item_name')` on this shape would produce inner groups with one detail row each — the inner group-footer would duplicate the detail row's value, which is visually redundant.
+- "Two-level" in the spec is most naturally read as **two levels of aggregation** (per-category subtotal + grand total), not two levels of grouping. That's exactly what `groupBy('category_name')` + `Column::sum()` produces.
+- ReportBuilder is still the right filler choice because it exercises the code-first path with per-group subtotals — a feature `DefinitionFiller`'s single-level grouping can also technically produce, but which the demo needs to showcase via the builder pattern regardless.
+
+If a reviewer disagrees and truly wants nested groups, the alternative is to change the data source's granularity to per-order-line (`{category_name, item_name, order_id, quantity, line_total_cents}`) so inner groups have multiple detail rows. That's a bigger refactor and would produce per-order-line detail rows, which is a different report. Flag on review; do not silently switch.
+
+**Sub-project ticket:** [012 — Sub-project A](../../tickets/012-implement-standalone-runtime-subproject-a.md) — A3.4 of A3.
+**Design spec:** [2026-08-23-a3-sample-reports-design.md](../specs/2026-08-23-a3-sample-reports-design.md) § A3.4.
+**Predecessor plan:** [A3.3 Open Tabs](2026-08-23-a3.3-open-tabs.md).
+
+**Related decisions:**
+- [ADR-002](../../09-conventions/decisions/002-sqlite-coffee-shop-toy-domain.md) — SQLite + coffee-shop domain
+- [ADR-011](../../09-conventions/decisions/011-docs-after-implementation.md) — no doc pages for code that doesn't exist yet
+- [ADR-013](../../09-conventions/decisions/013-framework-agnostic-library.md) — `writer-app/` is dev/test/demo scaffolding
+
+**Prerequisites:**
+- **A3.1 landed on `main`** — need `coffee-shop-mini.sql` fixture.
+- **A3.3 landed on `main`** — need the reusable `SnapshotAssertions` trait (which A3.2 introduced and A3.3 confirmed reusable).
+- Green suites on `main`:
+  - `cd writer && vendor/bin/phpunit` → `OK (163 tests, 300 assertions)`
+  - `cd writer-app && vendor/bin/phpunit` → `OK (70 tests, …)` after A3.3 lands
+- Docker available for the Task 6 end-to-end check.
+
+**Working directory:**
+- All PHP commands run from `/Users/leejenkins/dev/report-writer/writer-app/`.
+- Git commands run from `/Users/leejenkins/dev/report-writer/`.
+
+---
+
+## File Structure
+
+Everything new or modified is under `writer-app/`. Library (`writer/`) is not touched.
+
+```
+writer-app/
+├── src/
+│   ├── Kernel.php                                              # MODIFY — register provider + filler + ReportDefinition
+│   └── Reports/
+│       ├── SalesByCategoryItemFiller.php                       # NEW — ReportBuilder-based filler, mirrors DailySalesFiller shape
+│       └── DataSource/
+│           └── SqliteSalesByCategoryItemProvider.php           # NEW — one row per (category, item) with quantity_sold + total_cents
+└── tests/
+    ├── Snapshots/
+    │   └── sales-by-category-item.html                         # NEW — pinned HTML against coffee-shop-mini.sql
+    └── Unit/
+        └── Reports/
+            ├── SalesByCategoryItemFillerTest.php               # NEW — band-shape assertions (group headers, footers, summary)
+            ├── SalesByCategoryItemSnapshotTest.php             # NEW — reuses SnapshotAssertions trait
+            └── DataSource/
+                └── SqliteSalesByCategoryItemProviderTest.php   # NEW — row shape + date filter + open-tab exclusion + ordering
+```
+
+**File responsibilities:**
+
+- `SqliteSalesByCategoryItemProvider.php` — implements `ReportDataSourceInterface::fetchRows()`. Requires `$params['date']` YYYY-MM-DD. SQL joins `categories → items → order_items → orders`, filters `date(o.closed_at) = :date AND o.closed_at IS NOT NULL`, groups by `c.id, c.name, i.id, i.name`, orders by `c.name ASC, SUM(...) DESC, i.name ASC`.
+- `SalesByCategoryItemFiller.php` — implements `ReportFillerInterface`. Constructor takes the provider. `fill($params)` returns `ReportInstance` from `ReportBuilder::create('sales-by-category-item')`. Mirrors `DailySalesFiller` shape.
+- Three tests: provider (SQL correctness), filler (band shape), snapshot (byte-for-byte HTML). Splitting keeps failure attribution clean.
+- Kernel additions: three new lines (provider factory, filler factory, `ReportDefinition` entry) — smallest wiring surface in A3.
+
+---
+
+## Task 0: Verify baseline
+
+- [ ] **Step 1: Confirm branch state**
+
+Run: `git -C /Users/leejenkins/dev/report-writer status`
+Expected: `On branch main`, working tree clean, in sync with `origin/main`.
+
+- [ ] **Step 2: Confirm A3.3 landed**
+
+Run: `test -f /Users/leejenkins/dev/report-writer/writer-app/src/Reports/DataSource/SqliteOpenTabsProvider.php \
+   && test -f /Users/leejenkins/dev/report-writer/writer-app/tests/Support/SnapshotAssertions.php \
+   && echo OK`
+Expected: `OK`. If it prints nothing, A3.3 is not merged yet — stop and wait.
+
+- [ ] **Step 3: Confirm existing tests are green**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (70 tests, …)` (A3.3 baseline: 58 from A3.2 + 12 from A3.3).
+
+- [ ] **Step 4: Cut a feature branch**
+
+Run: `git -C /Users/leejenkins/dev/report-writer checkout -b feat/a3.4-sales-by-category-item`
+Expected: `Switched to a new branch 'feat/a3.4-sales-by-category-item'`.
+
+---
+
+## Task 1: Add `SqliteSalesByCategoryItemProvider` (TDD)
+
+**Files:**
+- Create: `writer-app/tests/Unit/Reports/DataSource/SqliteSalesByCategoryItemProviderTest.php`
+- Create: `writer-app/src/Reports/DataSource/SqliteSalesByCategoryItemProvider.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `writer-app/tests/Unit/Reports/DataSource/SqliteSalesByCategoryItemProviderTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports\DataSource;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryItemProvider;
+
+final class SqliteSalesByCategoryItemProviderTest extends TestCase
+{
+    private const FIXTURE = __DIR__ . '/../../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA  = __DIR__ . '/../../../../database/schema.sql';
+
+    public function testFetchRowsReturnsOneRowPerCategoryItemWithQuantityAndTotal(): void
+    {
+        // Fixture (date 2026-08-22) rows:
+        //   Coffee/Espresso  — order 1001 (1x500) + order 1003 (1x500) = qty 2, total 1000
+        //   Coffee/Latte     — order 1002 (2x600)                       = qty 2, total 1200
+        //   Pastry/Croissant — order 1001 (1x400)                       = qty 1, total  400
+        //   Pastry/Muffin    — order 1003 (1x350)                       = qty 1, total  350
+        // Sort: category ASC, total DESC, item ASC.
+        $rows = $this->fetch(['date' => '2026-08-22']);
+
+        $this->assertSame(
+            [
+                ['category_name' => 'Coffee', 'item_name' => 'Latte',     'quantity_sold' => 2, 'total_cents' => 1200],
+                ['category_name' => 'Coffee', 'item_name' => 'Espresso',  'quantity_sold' => 2, 'total_cents' => 1000],
+                ['category_name' => 'Pastry', 'item_name' => 'Croissant', 'quantity_sold' => 1, 'total_cents' =>  400],
+                ['category_name' => 'Pastry', 'item_name' => 'Muffin',    'quantity_sold' => 1, 'total_cents' =>  350],
+            ],
+            $rows
+        );
+    }
+
+    public function testFetchRowsExcludesOtherDates(): void
+    {
+        // Fixture has a 2026-08-21 latte (order 999) — must not appear in 2026-08-22 totals.
+        $rows = $this->fetch(['date' => '2026-08-22']);
+        $latteRow = null;
+        foreach ($rows as $r) {
+            if ($r['item_name'] === 'Latte') {
+                $latteRow = $r;
+            }
+        }
+        $this->assertNotNull($latteRow, 'Latte must appear for 2026-08-22');
+        $this->assertSame(2,    $latteRow['quantity_sold'], 'prior-day Latte must NOT roll into 2026-08-22');
+        $this->assertSame(1200, $latteRow['total_cents']);
+    }
+
+    public function testFetchRowsExcludesOpenTabs(): void
+    {
+        // Fixture order 2000 is an open tab with 1 espresso — must not add to Espresso totals.
+        $rows = $this->fetch(['date' => '2026-08-22']);
+        $espressoRow = null;
+        foreach ($rows as $r) {
+            if ($r['item_name'] === 'Espresso') {
+                $espressoRow = $r;
+            }
+        }
+        $this->assertNotNull($espressoRow);
+        $this->assertSame(2,    $espressoRow['quantity_sold'], 'open-tab espresso must NOT roll into totals');
+        $this->assertSame(1000, $espressoRow['total_cents']);
+    }
+
+    public function testFetchRowsReturnsEmptyForDateWithNoClosedOrders(): void
+    {
+        $this->assertSame([], $this->fetch(['date' => '2020-01-01']));
+    }
+
+    public function testFetchRowsRejectsMalformedDate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->fetch(['date' => 'yesterday']);
+    }
+
+    public function testFetchRowsRejectsMissingDate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->fetch([]);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<int, array{category_name: string, item_name: string, quantity_sold: int, total_cents: int}>
+     */
+    private function fetch(array $params): array
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+        return (new SqliteSalesByCategoryItemProvider($pdo))->fetchRows($params);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SqliteSalesByCategoryItemProviderTest`
+Expected: fatal `Class "ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryItemProvider" not found`.
+
+- [ ] **Step 3: Implement the provider**
+
+Create `writer-app/src/Reports/DataSource/SqliteSalesByCategoryItemProvider.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Reports\DataSource;
+
+use InvalidArgumentException;
+use PDO;
+use ReportWriter\Interfaces\ReportDataSourceInterface;
+
+final class SqliteSalesByCategoryItemProvider implements ReportDataSourceInterface
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * @param  array{date?: string} $params
+     * @return array<int, array{category_name: string, item_name: string, quantity_sold: int, total_cents: int}>
+     */
+    public function fetchRows(array $params): array
+    {
+        $date = $params['date'] ?? null;
+        if (!is_string($date) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+            throw new InvalidArgumentException("Parameter 'date' must be YYYY-MM-DD; got " . var_export($date, true));
+        }
+
+        $sql = <<<SQL
+            SELECT
+                c.name                                        AS category_name,
+                i.name                                        AS item_name,
+                SUM(oi.quantity)                              AS quantity_sold,
+                SUM(oi.quantity * oi.unit_price_cents)        AS total_cents
+            FROM categories c
+            JOIN items       i  ON i.category_id = c.id
+            JOIN order_items oi ON oi.item_id    = i.id
+            JOIN orders      o  ON o.id          = oi.order_id
+            WHERE date(o.closed_at) = :date
+              AND o.closed_at IS NOT NULL
+            GROUP BY c.id, c.name, i.id, i.name
+            ORDER BY c.name ASC, total_cents DESC, i.name ASC
+        SQL;
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['date' => $date]);
+
+        return array_map(
+            static fn (array $r): array => [
+                'category_name' => (string) $r['category_name'],
+                'item_name'     => (string) $r['item_name'],
+                'quantity_sold' => (int)    $r['quantity_sold'],
+                'total_cents'   => (int)    $r['total_cents'],
+            ],
+            $stmt->fetchAll()
+        );
+    }
+}
+```
+
+Notes on the SQL:
+- `GROUP BY c.id, c.name, i.id, i.name` (all four) — safe against duplicate `name` values in either table if the seed ever grows.
+- Ordering: **category ASC** (outer group key stable for group-by-category), **total DESC** (best-selling first within category), **item ASC** as tiebreaker for equal totals.
+- Matches the exclusion invariants A3.2 established: prior-day orders excluded via `date()`, open tabs excluded via `IS NOT NULL`.
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SqliteSalesByCategoryItemProviderTest`
+Expected: `OK (6 tests, …)`.
+
+- [ ] **Step 5: Confirm no regression**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (76 tests, …)` (70 baseline + 6 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/src/Reports/DataSource/SqliteSalesByCategoryItemProvider.php \
+        writer-app/tests/Unit/Reports/DataSource/SqliteSalesByCategoryItemProviderTest.php
+git commit -m "feat(reports): SqliteSalesByCategoryItemProvider (A3.4)"
+```
+
+---
+
+## Task 2: Add `SalesByCategoryItemFiller` (TDD)
+
+**Files:**
+- Create: `writer-app/tests/Unit/Reports/SalesByCategoryItemFillerTest.php`
+- Create: `writer-app/src/Reports/SalesByCategoryItemFiller.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `writer-app/tests/Unit/Reports/SalesByCategoryItemFillerTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryItemProvider;
+use ReportWriter\App\Reports\SalesByCategoryItemFiller;
+use ReportWriter\Instance\ReportInstance;
+
+final class SalesByCategoryItemFillerTest extends TestCase
+{
+    private const FIXTURE = __DIR__ . '/../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA  = __DIR__ . '/../../../database/schema.sql';
+
+    public function testFillProducesReportInstanceWithExpectedIdAndBands(): void
+    {
+        $instance = $this->fill(['date' => '2026-08-22']);
+
+        $this->assertInstanceOf(ReportInstance::class, $instance);
+        $this->assertSame('sales-by-category-item', $instance->getReportInstanceId());
+
+        $bands = $instance->getBandInstances();
+        $this->assertNotEmpty($bands);
+
+        // Expected band sequence for the fixture with one groupBy('category_name'):
+        //   title, col-header, group-header(Coffee), detail(Latte), detail(Espresso),
+        //   group-footer(Coffee), group-header(Pastry), detail(Croissant),
+        //   detail(Muffin), group-footer(Pastry), summary
+        $types = array_map(fn ($b) => $b->getBandType(), $bands);
+        $this->assertSame(
+            [
+                'title',
+                'col-header',
+                'group-header', 'detail', 'detail', 'group-footer',
+                'group-header', 'detail', 'detail', 'group-footer',
+                'summary',
+            ],
+            $types
+        );
+    }
+
+    public function testFillProducesTitleWithDateInterpolated(): void
+    {
+        $instance = $this->fill(['date' => '2026-08-22']);
+        $titleBand = $instance->getBandInstances()[0];
+        $titleText = $titleBand->getElements()[0]->getContent()->getValue();
+        $this->assertStringContainsString('2026-08-22', $titleText);
+        $this->assertStringContainsString('Sales by Category', $titleText);
+    }
+
+    public function testFillProducesFewerBandsWhenNoDataForDate(): void
+    {
+        $empty = $this->fill(['date' => '2020-01-01']);
+        $full  = $this->fill(['date' => '2026-08-22']);
+
+        $this->assertLessThan(
+            count($full->getBandInstances()),
+            count($empty->getBandInstances()),
+            'empty-date report must have fewer bands than populated-date report'
+        );
+    }
+
+    /** @param array<string, mixed> $params */
+    private function fill(array $params): ReportInstance
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+        return (new SalesByCategoryItemFiller(new SqliteSalesByCategoryItemProvider($pdo)))->fill($params);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SalesByCategoryItemFillerTest`
+Expected: fatal `Class "ReportWriter\App\Reports\SalesByCategoryItemFiller" not found`.
+
+- [ ] **Step 3: Implement the filler**
+
+Create `writer-app/src/Reports/SalesByCategoryItemFiller.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Reports;
+
+use ReportWriter\Builder\Column;
+use ReportWriter\Builder\ReportBuilder;
+use ReportWriter\Instance\ReportInstance;
+use ReportWriter\Interfaces\ReportDataSourceInterface;
+use ReportWriter\Interfaces\ReportFillerInterface;
+use ReportWriter\Registry\FormatterRegistry;
+
+final class SalesByCategoryItemFiller implements ReportFillerInterface
+{
+    private ReportDataSourceInterface $provider;
+
+    public function __construct(ReportDataSourceInterface $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    public function fill(array $params): ReportInstance
+    {
+        $date     = $params['date'] ?? '';
+        $rows     = $this->provider->fetchRows($params);
+        $currency = FormatterRegistry::defaults()->get('cents');
+
+        return ReportBuilder::create('sales-by-category-item')
+            ->title("Sales by Category → Item — {$date}")
+            ->columns([
+                Column::make('item_name',     'Item',  0,   300)->alignLeft(),
+                Column::make('quantity_sold', 'Qty',   300,  90)->alignRight()->sum(),
+                Column::make('total_cents',   'Total', 390,  90)
+                    ->alignRight()
+                    ->sum()
+                    ->format($currency),
+            ])
+            ->rows($rows)
+            ->groupBy('category_name')
+            ->build();
+    }
+}
+```
+
+Notes:
+- **`Column::sum()` on both Qty and Total** — installs an `AggregateExpression` on the footer AND summary expressions simultaneously (see `writer/src/Builder/Column.php::withAggregate()`). That's why per-group subtotals and grand total both come from a single `->sum()` shortcut per column.
+- **Item column has no aggregate** — its footer expression stays null; group-footer + summary render an empty element in that column. Verified by the snapshot test.
+- **`->groupBy('category_name')`** — one grouping level. Detail rows are per-item (one per row from the provider).
+- **Format applied only to Total** — Qty is a count, keeps as integer.
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SalesByCategoryItemFillerTest`
+Expected: `OK (3 tests, …)`.
+
+- [ ] **Step 5: Confirm no regression**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (79 tests, …)` (76 after Task 1 + 3 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/src/Reports/SalesByCategoryItemFiller.php \
+        writer-app/tests/Unit/Reports/SalesByCategoryItemFillerTest.php
+git commit -m "feat(reports): SalesByCategoryItemFiller with groupBy(category_name) (A3.4)"
+```
+
+---
+
+## Task 3: Wire in `Kernel.php`
+
+**Files:**
+- Modify: `writer-app/src/Kernel.php`
+- Create: `writer-app/tests/Unit/ContainerA34WiringTest.php`
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Create `writer-app/tests/Unit/ContainerA34WiringTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Config;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Kernel;
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryItemProvider;
+use ReportWriter\App\Reports\ReportRegistry;
+use ReportWriter\App\Reports\SalesByCategoryItemFiller;
+
+final class ContainerA34WiringTest extends TestCase
+{
+    private function container(): \ReportWriter\App\Container
+    {
+        // Same pattern as A3.2/A3.3 wiring tests.
+        $c = Kernel::defaultContainer(new Config(':memory:', false));
+        $c->set(PDO::class, static fn () => SqliteConnectionFactory::createInMemoryWithSchema(
+            __DIR__ . '/../../database/schema.sql'
+        ));
+        return $c;
+    }
+
+    public function testProviderIsResolvable(): void
+    {
+        $provider = $this->container()->get(SqliteSalesByCategoryItemProvider::class);
+        $this->assertInstanceOf(SqliteSalesByCategoryItemProvider::class, $provider);
+    }
+
+    public function testFillerIsResolvable(): void
+    {
+        $filler = $this->container()->get(SalesByCategoryItemFiller::class);
+        $this->assertInstanceOf(SalesByCategoryItemFiller::class, $filler);
+    }
+
+    public function testReportRegistryExposesSalesByCategoryItemDefinition(): void
+    {
+        $registry = $this->container()->get(ReportRegistry::class);
+        $def = $registry->get('sales-by-category-item');
+        $this->assertSame('sales-by-category-item',                       $def->getId());
+        $this->assertSame('Sales by Category → Item',                     $def->getLabel());
+        $this->assertSame(SalesByCategoryItemFiller::class,               $def->getFillerServiceId());
+        $params = $def->getParams();
+        $this->assertCount(1, $params);
+        $this->assertSame('date', $params[0]->getName());
+        $this->assertTrue($params[0]->isRequired());
+    }
+
+    public function testReportRegistryStillExposesPredecessorReports(): void
+    {
+        // Regression guard: A3.4 must not overwrite prior registrations.
+        $registry = $this->container()->get(ReportRegistry::class);
+        $this->assertSame('daily-sales',       $registry->get('daily-sales')->getId());
+        $this->assertSame('sales-by-category', $registry->get('sales-by-category')->getId());
+        $this->assertSame('open-tabs',         $registry->get('open-tabs')->getId());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter ContainerA34WiringTest`
+Expected: three tests fail (provider + filler + definition unresolvable). The regression-guard test should already pass.
+
+- [ ] **Step 3: Wire the new services in `Kernel.php`**
+
+Open `writer-app/src/Kernel.php`. Add these `use` lines to the existing block (keep alphabetical):
+
+```php
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryItemProvider;
+use ReportWriter\App\Reports\SalesByCategoryItemFiller;
+```
+
+Register the provider + filler factories near the existing `SqliteOpenTabsProvider` block (position doesn't matter — just keep related things together):
+
+```php
+        $c->set(SqliteSalesByCategoryItemProvider::class,
+            static fn (Container $c) => new SqliteSalesByCategoryItemProvider($c->get(PDO::class)));
+
+        $c->set(SalesByCategoryItemFiller::class,
+            static fn (Container $c) => new SalesByCategoryItemFiller($c->get(SqliteSalesByCategoryItemProvider::class)));
+```
+
+Extend the `ReportRegistry` factory:
+
+```php
+        $c->set(ReportRegistry::class, static fn () => new ReportRegistry([
+            new ReportDefinition('daily-sales',       'Daily Sales',        DailySalesFiller::class,   [new ParamSpec('date', 'date', true)]),
+            new ReportDefinition('sales-by-category', 'Sales by Category',  'sales-by-category.filler',[new ParamSpec('date', 'date', true)]),
+            new ReportDefinition('open-tabs',         'Open Tabs',          'open-tabs.filler',        []),
+            new ReportDefinition(                     // ← NEW
+                'sales-by-category-item',
+                'Sales by Category → Item',
+                SalesByCategoryItemFiller::class,
+                [new ParamSpec('date', 'date', true)]
+            ),
+        ]));
+```
+
+Rationale: `SalesByCategoryItemFiller` is `ReportBuilder`-based (not `DefinitionFiller`) — it does NOT need to register a source in `DataSourceRegistry`, does NOT need a `{id}.filler` service. Same pattern as `DailySalesFiller`.
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter ContainerA34WiringTest`
+Expected: `OK (4 tests, …)`.
+
+- [ ] **Step 5: Confirm no regression across the whole suite**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (83 tests, …)` (79 after Task 2 + 4 wiring tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/src/Kernel.php writer-app/tests/Unit/ContainerA34WiringTest.php
+git commit -m "feat(kernel): wire SalesByCategoryItemFiller (A3.4)"
+```
+
+---
+
+## Task 4: Snapshot test + snapshot file
+
+**Files:**
+- Create: `writer-app/tests/Unit/Reports/SalesByCategoryItemSnapshotTest.php`
+- Create: `writer-app/tests/Snapshots/sales-by-category-item.html`
+
+- [ ] **Step 1: Write the snapshot test**
+
+Create `writer-app/tests/Unit/Reports/SalesByCategoryItemSnapshotTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports;
+
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Database\SqliteConnectionFactory;
+use ReportWriter\App\Reports\DataSource\SqliteSalesByCategoryItemProvider;
+use ReportWriter\App\Reports\SalesByCategoryItemFiller;
+use ReportWriter\App\Tests\Support\SnapshotAssertions;
+use ReportWriter\Layout\Flattener;
+use ReportWriter\Layout\LayoutService;
+use ReportWriter\Layout\PageConfig;
+use ReportWriter\Renderer\HtmlRenderer;
+
+final class SalesByCategoryItemSnapshotTest extends TestCase
+{
+    use SnapshotAssertions;
+
+    private const FIXTURE  = __DIR__ . '/../../Fixtures/coffee-shop-mini.sql';
+    private const SCHEMA   = __DIR__ . '/../../../database/schema.sql';
+    private const SNAPSHOT = __DIR__ . '/../../Snapshots/sales-by-category-item.html';
+
+    public function testRendersByteForByteMatchOfSnapshotOnFixture(): void
+    {
+        $pdo = SqliteConnectionFactory::createInMemoryWithSchema(self::SCHEMA);
+        $pdo->exec((string) file_get_contents(self::FIXTURE));
+
+        $filler   = new SalesByCategoryItemFiller(new SqliteSalesByCategoryItemProvider($pdo));
+        $instance = $filler->fill(['date' => '2026-08-22']);
+
+        $page   = new PageConfig();
+        $stream = (new LayoutService(new Flattener(), $page))->layout($instance);
+        $html   = (new HtmlRenderer($page))->render($stream);
+
+        $this->assertSnapshotMatches($html, self::SNAPSHOT);
+    }
+}
+```
+
+- [ ] **Step 2: Bootstrap the snapshot**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SalesByCategoryItemSnapshotTest`
+Expected: `1) …testRendersByteForByteMatchOfSnapshotOnFixture` fails with `Snapshot bootstrapped at .../sales-by-category-item.html. Re-run the test to verify.`
+
+- [ ] **Step 3: Verify the bootstrapped snapshot contains the expected content**
+
+Automated check:
+
+```bash
+cd /Users/leejenkins/dev/report-writer/writer-app && \
+for token in 'Sales by Category → Item — 2026-08-22' 'Item' 'Qty' 'Total' 'Coffee' 'Latte' 'Espresso' 'Pastry' 'Croissant' 'Muffin' '$12.00' '$10.00' '$22.00' '$4.00' '$3.50' '$7.50' '$29.50'; do
+    if ! grep -qF "$token" tests/Snapshots/sales-by-category-item.html; then
+        echo "MISSING: $token" && exit 1
+    fi
+done
+echo OK
+```
+
+Expected: `OK`. Fixture-derived expectations:
+- Title: `Sales by Category → Item — 2026-08-22` (centered)
+- Column headers: `Item`, `Qty`, `Total`
+- Coffee group: `Latte` ($12.00), `Espresso` ($10.00), subtotal $22.00
+- Pastry group: `Croissant` ($4.00), `Muffin` ($3.50), subtotal $7.50
+- Grand Total: $29.50
+
+If any token is missing:
+- Missing group header/footer → `->groupBy('category_name')` missing.
+- Missing subtotal amounts → `Column::sum()` not applied to Total column.
+- Wrong ordering within group → SQL `ORDER BY total_cents DESC` missing.
+- Missing `→` character (arrow) — copy-paste it exactly: U+2192.
+
+Do NOT rerun with `UPDATE_SNAPSHOTS=1` until the failure is understood.
+
+Optional (when a human is present): open `writer-app/tests/Snapshots/sales-by-category-item.html` in a browser to eyeball layout.
+
+- [ ] **Step 4: Rerun to confirm GREEN**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --filter SalesByCategoryItemSnapshotTest`
+Expected: `OK (1 test, 1 assertion)`.
+
+- [ ] **Step 5: Confirm no regression**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (84 tests, …)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/tests/Unit/Reports/SalesByCategoryItemSnapshotTest.php \
+        writer-app/tests/Snapshots/sales-by-category-item.html
+git commit -m "test(reports): snapshot Sales by Category → Item (A3.4)"
+```
+
+---
+
+## Task 5: Smoke test — the report is reachable via HTTP
+
+**Files:**
+- Modify: `writer-app/tests/Smoke/ReportRenderSmokeTest.php`
+
+- [ ] **Step 1: Add a fourth test method**
+
+Append (matching the file's style — reuse the same `AppFactory::buildTestApp()` + `ServerRequestFactory` pattern the existing smoke tests use):
+
+```php
+    public function testSalesByCategoryItemRespondsWithHtml(): void
+    {
+        $pdo = DailySalesFixture::newPdo();
+
+        $app = AppFactory::buildTestApp(static function (Container $c) use ($pdo): void {
+            $c->set(PDO::class, static fn () => $pdo);
+        });
+
+        $request  = (new ServerRequestFactory())->createServerRequest('GET', '/api/reports/sales-by-category-item?date=2026-08-22');
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringStartsWith('text/html', $response->getHeaderLine('Content-Type'));
+        $this->assertStringContainsString('Sales by Category', (string) $response->getBody());
+    }
+```
+
+- [ ] **Step 2: Run the smoke test**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit --testsuite Smoke`
+Expected: all four smoke tests pass (Daily Sales, Sales by Category, Open Tabs, Sales by Category → Item).
+
+Fallback if the suite name differs: `vendor/bin/phpunit tests/Smoke/ReportRenderSmokeTest.php`.
+
+- [ ] **Step 3: Full suite green**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer-app && vendor/bin/phpunit`
+Expected: `OK (85 tests, …)`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/leejenkins/dev/report-writer
+git add writer-app/tests/Smoke/ReportRenderSmokeTest.php
+git commit -m "test(smoke): /api/reports/sales-by-category-item returns HTML (A3.4)"
+```
+
+---
+
+## Task 6: End-to-end verification + push + PR
+
+- [ ] **Step 1: Confirm the library suite is unaffected**
+
+Run: `cd /Users/leejenkins/dev/report-writer/writer && vendor/bin/phpunit`
+Expected: `OK (163 tests, 300 assertions)` — unchanged.
+
+- [ ] **Step 2: Bring the demo up**
+
+Run: `cd /Users/leejenkins/dev/report-writer && ./scripts/demo-up`
+Wait for the "Demo is up" banner.
+
+- [ ] **Step 3: Hit the new endpoint**
+
+Run:
+```bash
+curl -sS -D - 'http://localhost:8090/api/reports/sales-by-category-item?date=2026-08-22' -o /tmp/sbci.html | head -5
+```
+Expected header block: `HTTP/1.1 200 OK`, `Content-Type: text/html; charset=utf-8`.
+
+Then:
+```bash
+grep -c 'Sales by Category' /tmp/sbci.html
+```
+Expected: `1` or greater.
+
+Then confirm the group-header + subtotal structure appears:
+```bash
+grep -c 'fu-band-group-header' /tmp/sbci.html
+grep -c 'fu-band-group-footer' /tmp/sbci.html
+```
+Expected: both counts equal the number of categories in the demo seed (should match). If they differ, `->groupBy()` is dropping something.
+
+- [ ] **Step 4: Verify predecessor reports still work**
+
+Run:
+```bash
+for id in daily-sales 'sales-by-category?date=2026-08-22' open-tabs 'sales-by-category-item?date=2026-08-22'; do
+    printf '%-45s ' "/api/reports/$id"
+    curl -sS -o /dev/null -w '%{http_code}\n' "http://localhost:8090/api/reports/$id"
+done
+```
+Expected: four `200` lines.
+
+- [ ] **Step 5: (Optional) browser smoke**
+
+Open `http://localhost:8090/api/reports/sales-by-category-item?date=2026-08-22` in a browser. Confirm the title reads "Sales by Category → Item — 2026-08-22", category group headers appear between item lists, subtotals appear between groups, grand total appears at the bottom.
+
+- [ ] **Step 6: Tear down (or leave up for A3.5)**
+
+Run: `cd /Users/leejenkins/dev/report-writer && docker compose down`
+
+- [ ] **Step 7: Push the branch and open the PR**
+
+```bash
+git -C /Users/leejenkins/dev/report-writer push -u origin feat/a3.4-sales-by-category-item
+
+gh pr create --repo edgecase123/report-writer \
+  --title "feat(A3.4): Sales by Category → Item report" \
+  --body "$(cat <<'EOF'
+## Summary
+- **New report:** \`GET /api/reports/sales-by-category-item?date=YYYY-MM-DD\` — per-item sales aggregated by category, one grouping level (category), per-category subtotals, grand total footer.
+- **First ReportBuilder-based sample report in A3.** \`SalesByCategoryItemFiller\` mirrors \`DailySalesFiller\` shape and uses the fluent \`ReportBuilder::create(...)->title(...)->columns([...])->rows($rows)->groupBy('category_name')->build()\` pattern.
+- **\`Column::sum()\`** on Qty and Total installs one \`AggregateExpression\` shared by both group-footer and summary contexts — per-category subtotals and grand total come from a single shortcut per column.
+- No JSON template, no \`DataSourceRegistry\` involvement — ReportBuilder path is separate from the JSON-templated path A3.2 established.
+- Snapshot pinned against A3.1's \`coffee-shop-mini.sql\` fixture: Coffee ($22.00, Latte $12.00 + Espresso $10.00), Pastry ($7.50, Croissant $4.00 + Muffin $3.50), Grand Total $29.50.
+
+Design: [A3 spec](docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md) § A3.4.
+Plan:   [A3.4 plan](docs/superpowers/plans/2026-08-23-a3.4-sales-by-category-item.md).
+
+## Test plan
+- [x] \`cd writer && vendor/bin/phpunit\` → \`OK (163 tests, 300 assertions)\` — unchanged
+- [x] \`cd writer-app && vendor/bin/phpunit\` → \`OK (85 tests, …)\` (70 A3.3 baseline + 15 new)
+- [x] Snapshot: \`writer-app/tests/Snapshots/sales-by-category-item.html\` matches fixture
+- [x] Smoke: \`GET /api/reports/sales-by-category-item?date=2026-08-22\` returns 200 + HTML with group-header + group-footer bands
+- [x] All four reports return 200 (daily-sales, sales-by-category, open-tabs, sales-by-category-item)
+
+## Design note (from plan)
+The A3 spec calls this "two-level groups"; the plan interprets that as two levels of aggregation (subtotal + grand total) with one grouping level (by category). See plan's "Design decision" section for full reasoning + the alternative if the interpretation is wrong.
+EOF
+)"
+```
+
+No `🤖 Generated with Claude Code` trailer. No `Co-Authored-By: Claude` trailer.
+
+- [ ] **Step 8: Post the PR link in `#report`**
+
+`#report` — one line: `A3.4 open: <PR URL>. Docker mount free.`
+
+---
+
+## Rollback plan
+
+If Task 4 snapshot diverges or Task 6 curl returns non-200:
+
+1. Read the emitted HTML first. Compare against expected group + subtotal + grand-total shape.
+2. **No group-header / group-footer bands** → `->groupBy('category_name')` missing from the filler.
+3. **Wrong subtotal amounts** → `Column::sum()` not applied to the Total column, or the aggregate is looking at the wrong field.
+4. **Item order wrong within group** → provider SQL missing `ORDER BY … total_cents DESC …`.
+5. **Prior-day or open-tab rows in totals** → provider missing `date(o.closed_at) = :date AND o.closed_at IS NOT NULL`.
+6. **404 or 500 on the endpoint** → `SalesByCategoryItemFiller` factory not registered in `Kernel.php`, or `ReportDefinition` for `sales-by-category-item` missing from `ReportRegistry`.
+7. **Reviewer disagrees with single-groupBy interpretation** → see plan's Design decision section. Alternative is a bigger refactor (per-order-line data granularity + `->groupBy('category_name', 'item_name')`) — file as a follow-up ticket, do not silently switch inside this PR.
+8. `git reset --hard main` on the feature branch discards the whole thing — use only if the rewrite is smaller than the fix.
+
+## Self-review checklist (executed 2026-08-23 when this plan was written)
+
+- **Spec coverage:**
+  - "Filler: `SalesByCategoryItemFiller implements ReportFillerInterface`, using `ReportBuilder::groupBy(...)->groupBy(...)` internally" → Task 2. Deviated from `groupBy(...)->groupBy(...)` to single `groupBy(...)` — explicitly justified in the "Design decision" section up-front + surfaced in rollback plan step 7.
+  - "Data source: `SqliteSalesByCategoryItemProvider` — one row per `(category_id, item_id)` with `category_name, item_name, quantity_sold, total_cents`" → Task 1.
+  - "Report: two-level groups; per-item detail line; per-category subtotal; grand total footer" → Task 2 (filler shape) + Task 4 (snapshot verifies bands + amounts).
+  - "Rationale for ReportBuilder: DefinitionFiller supports only one grouping level" → plan's "Design decision" section addresses this directly; keeps ReportBuilder even with one groupBy because the demo needs to showcase the code-first pattern.
+- **Placeholder scan:** none. Design ambiguity is surfaced concretely up-front + reflected in rollback plan.
+- **Type / name consistency:** service id `SalesByCategoryItemFiller::class` used identically in Kernel (Task 3), ReportRegistry entry (Task 3), and wiring test (Task 3). Report id `sales-by-category-item` consistent across File Structure, Task 2 (filler), Task 3 (registry), Task 5 (smoke URL), Task 6 (curl URL). Provider class `SqliteSalesByCategoryItemProvider` consistent across all tasks.
+- **Cross-plan consistency:** wiring test pattern matches A3.2/A3.3 exactly (`Kernel::defaultContainer(new Config(':memory:', false))` + PDO overwrite). Snapshot test pattern matches A3.2/A3.3. Regression-guard test enumerates all four prior reports.
+- **Task cadence:** Tasks 1, 2, 3, 4, 5 each end in a commit. Task 6 pushes + opens the PR. Rollback maps failures back to specific tasks.


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/plans/2026-08-23-a3.4-sales-by-category-item.md` — the implementation plan for A3.4 of Sub-project A.
- 6 tasks, TDD-driven, docs-only in this PR.
- **First ReportBuilder-based sample report in A3.** No JSON template, no `DataSourceRegistry` involvement — the code-first filler path (same shape as `DailySalesFiller`).
- Sequenced after **A3.3 (PR #24)** because Task 0 baseline asserts A3.3's tests are green (needs the SnapshotAssertions trait from A3.2 which A3.3 confirmed reusable).

## Design note

The A3 spec calls A3.4 "two-level groups" and cites the ReportBuilder rationale as "nested groups required." This plan implements **one grouping level** (by `category_name`) with per-item detail rows, interpreting "two-level" as **two levels of aggregation** (per-category subtotal + grand total). Full reasoning + alternative interpretation surfaced up-front in the plan's "Design decision" section and echoed in the rollback plan. Flag on review if you want genuinely-nested groups — that's a data-granularity refactor (per-order-line rows), filed as a separate concern.

## Plan shape

- Task 0: baseline (requires A3.3 landed)
- Task 1: `SqliteSalesByCategoryItemProvider` (6 unit tests: shape, date filter, open-tab exclusion, ordering, empty case, malformed date)
- Task 2: `SalesByCategoryItemFiller` (3 tests: band shape/count, title interpolation, fewer-bands-when-empty)
- Task 3: wire `Kernel.php` — provider + filler factories + `ReportDefinition` entry (4 wiring tests inc. regression guards for A3.1/A3.2/A3.3 registrations)
- Task 4: snapshot test (reuses `SnapshotAssertions` trait; 17-token content check)
- Task 5: extend smoke test with `/api/reports/sales-by-category-item`
- Task 6: verify library unchanged + demo curl (all four reports) + push + PR

## Design references

- Spec: `docs/superpowers/specs/2026-08-23-a3-sample-reports-design.md` § A3.4
- Predecessor: `docs/superpowers/plans/2026-08-23-a3.3-open-tabs.md`

## Test plan

- [ ] Sibling agent peer review — ping in coordination channel post-open
- [ ] N/A — no code changes in this PR; the plan itself is the deliverable