### PR TITLE
refactor(renderer): rename CSS prefix fu- → rw- (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project is pre-1.0 and does not yet follow semantic versioning.
+
+## Unreleased
+
+### Changed
+
+- **Library CSS class prefix renamed from `fu-` to `rw-`.** The `Renderer\HtmlRenderer`
+  now emits `rw-page`, `rw-el`, `rw-band-overlay`, `rw-band-overlay-<type>`, and
+  `rw-band-<type>` classes on the report HTML it renders. The `rw-` prefix matches
+  the PHP namespace (`ReportWriter\`) and the published Composer package name
+  (`edgecase123/report-writer`).
+
+  **Breaking change for downstream CSS consumers:** any consumer application that
+  styles report elements via `.fu-*` selectors must update those selectors to
+  `.rw-*`. Bundled test snapshots (`writer-app/tests/Snapshots/*.html`) and the
+  Vue viewer (`frontend/src/components/ReportCanvas.vue`) have been updated in the
+  same change.
+
+  This change lands pre-1.0 with no compatibility shim.

--- a/docs/03-concepts/what-is-a-report.md
+++ b/docs/03-concepts/what-is-a-report.md
@@ -128,7 +128,7 @@ Deep dive in [Expressions and formatters](expressions-and-formatters.md) (planne
 
 After layout, the report is split into pages. Each page is a list of **positioned elements** — every element from every band that ended up on that page, with its absolute `(x, y)` computed from the band's position plus the element's in-band offset.
 
-A page is what a renderer emits. HTML renders one page as one `<div class="fu-page">`; JSON renders one page as one array of positioned-element objects.
+A page is what a renderer emits. HTML renders one page as one `<div class="rw-page">`; JSON renders one page as one array of positioned-element objects.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-23-title-alignment-design.md
+++ b/docs/superpowers/specs/2026-08-23-title-alignment-design.md
@@ -16,7 +16,7 @@ $titleBand  = new BandInstance('band_title', 'title', [
 ]);
 ```
 
-The title element's width is derived from the columns' extent. `StyleMap`'s default CSS applies `text-align: center` to `.fu-band-title`, so text centers *within the title element's box*. When columns don't span the printable page width — the common case — the title's box is narrower than the page, and the visual result appears left-of-page-center.
+The title element's width is derived from the columns' extent. `StyleMap`'s default CSS applies `text-align: center` to `.rw-band-title`, so text centers *within the title element's box*. When columns don't span the printable page width — the common case — the title's box is narrower than the page, and the visual result appears left-of-page-center.
 
 The visible symptom (off-center title) is a leading indicator of a deeper architectural smell: **one band is derived from another band's contents**. That coupling is always wrong; it just happens to *look* right when columns extent equals printable area.
 

--- a/docs/tickets/017-title-alignment-vs-columns-vs-page.md
+++ b/docs/tickets/017-title-alignment-vs-columns-vs-page.md
@@ -16,7 +16,7 @@ $bands[] = new BandInstance('band_title', 'title', [
 ]);
 ```
 
-`totalWidth()` returns `max(column.x + column.width)` across all columns. The library's default StyleMap (`writer/src/Renderer/StyleMap.php:38-43`) applies `text-align: center` to `.fu-band-title`.
+`totalWidth()` returns `max(column.x + column.width)` across all columns. The library's default StyleMap (`writer/src/Renderer/StyleMap.php:38-43`) applies `text-align: center` to `.rw-band-title`.
 
 Consequence: the title centers within the columns-extent box, not the printable-page-width area. On reports where columns are narrower than the printable area (e.g. three 120pt columns on a Letter page with 20pt margins → columns span 380pt, printable area is ~572pt), the title visually appears left-of-page-center by ~96pt.
 

--- a/frontend/src/components/ReportCanvas.vue
+++ b/frontend/src/components/ReportCanvas.vue
@@ -94,12 +94,12 @@ async function load(): Promise<void> {
             .map((s) => s.outerHTML)
             .join('\n');
 
-        // Extract base page dimensions from the first .fu-page element's inline
+        // Extract base page dimensions from the first .rw-page element's inline
         // style. HtmlRenderer::renderPage emits e.g. style="width:612.00pt;height:792.00pt;".
         // These dimensions size the .report-scaler wrapper so the scroll
         // container reserves the correct horizontal space at any zoom level
         // (Ticket 007 — reserved-width wrapper approach).
-        const firstPage = doc.querySelector('.fu-page') as HTMLElement | null;
+        const firstPage = doc.querySelector('.rw-page') as HTMLElement | null;
         if (firstPage) {
             const w = parsePtLength(firstPage.style.width);
             const h = parsePtLength(firstPage.style.height);
@@ -107,14 +107,14 @@ async function load(): Promise<void> {
             basePageHeight.value = h ?? DEFAULT_PAGE_HEIGHT;
             if (w === null || h === null) {
                 console.warn(
-                    '[ReportCanvas] .fu-page found but width/height style unparsable; falling back to US Letter (612x792).'
+                    '[ReportCanvas] .rw-page found but width/height style unparsable; falling back to US Letter (612x792).'
                 );
             }
         } else {
             basePageWidth.value  = DEFAULT_PAGE_WIDTH;
             basePageHeight.value = DEFAULT_PAGE_HEIGHT;
             console.warn(
-                '[ReportCanvas] No .fu-page element in report HTML; falling back to US Letter (612x792) for scaler dimensions.'
+                '[ReportCanvas] No .rw-page element in report HTML; falling back to US Letter (612x792) for scaler dimensions.'
             );
         }
 
@@ -176,8 +176,8 @@ let activePointerId: number | null = null;
 
 function isTextTarget(target: EventTarget | null): boolean {
     // Report HTML from HtmlRenderer places each text value in its own leaf
-    // <div class="fu-el ..."> whose direct child is a Text node. Container
-    // elements (.viewer-canvas, .report-scaler, .report-inner, .fu-page) have
+    // <div class="rw-el ..."> whose direct child is a Text node. Container
+    // elements (.viewer-canvas, .report-scaler, .report-inner, .rw-page) have
     // element children only. So "clicked on text" ≡ "target has a direct
     // TEXT_NODE child with non-whitespace content." caretPositionFromPoint
     // was tried first but snaps to the nearest text even for background

--- a/writer-app/tests/Snapshots/open-tabs.html
+++ b/writer-app/tests/Snapshots/open-tabs.html
@@ -5,18 +5,18 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <style>
 body{margin:0;padding:20pt;background:#e0e0e0;font-family:sans-serif}
-.fu-page{position:relative;background:#fff;margin:0 auto 24pt;box-shadow:0 2px 8px rgba(0,0,0,.25);overflow:hidden}
-.fu-el{position:absolute;box-sizing:border-box;font-size:9pt;line-height:1.3;overflow:hidden;white-space:pre-wrap}
-.fu-band-overlay{position:absolute;left:0;width:100%;pointer-events:none;}
-.fu-band-title{font-size:14pt;font-weight:bold;text-align:center;color:#1a1a2e;}.fu-band-col-header{font-weight:bold;}.fu-band-group-header{font-weight:bold;color:#1a1a2e;}.fu-band-group-footer{font-style:italic;color:#555555;}.fu-band-summary{color:#555555;font-style:italic;}.fu-band-overlay-col-header{border-bottom:1px solid #333;}
+.rw-page{position:relative;background:#fff;margin:0 auto 24pt;box-shadow:0 2px 8px rgba(0,0,0,.25);overflow:hidden}
+.rw-el{position:absolute;box-sizing:border-box;font-size:9pt;line-height:1.3;overflow:hidden;white-space:pre-wrap}
+.rw-band-overlay{position:absolute;left:0;width:100%;pointer-events:none;}
+.rw-band-title{font-size:14pt;font-weight:bold;text-align:center;color:#1a1a2e;}.rw-band-col-header{font-weight:bold;}.rw-band-group-header{font-weight:bold;color:#1a1a2e;}.rw-band-group-footer{font-style:italic;color:#555555;}.rw-band-summary{color:#555555;font-style:italic;}.rw-band-overlay-col-header{border-bottom:1px solid #333;}
 @media print{
 @page{margin:0}
 body{padding:0;background:none}
-.fu-page{margin:0;box-shadow:none;break-after:page;page-break-after:always}
-.fu-page:last-child{break-after:avoid;page-break-after:avoid}
+.rw-page{margin:0;box-shadow:none;break-after:page;page-break-after:always}
+.rw-page:last-child{break-after:avoid;page-break-after:avoid}
 }
 </style>
 </head>
 <body>
-<div class="fu-page" style="width:612.00pt;height:792.00pt;" data-page="1"><div class="fu-el fu-band-title" style="left:20.00pt;top:20.00pt;width:572.00pt;height:24.00pt;text-align:center;">Open Tabs</div><div class="fu-el fu-band-col-header" style="left:20.00pt;top:44.00pt;width:120.00pt;height:16.00pt;text-align:left;">Order</div><div class="fu-el fu-band-col-header" style="left:140.00pt;top:44.00pt;width:200.00pt;height:16.00pt;text-align:left;">Opened</div><div class="fu-el fu-band-col-header" style="left:340.00pt;top:44.00pt;width:160.00pt;height:16.00pt;text-align:right;">Running Total</div><div class="fu-el fu-band-detail" style="left:20.00pt;top:60.00pt;width:120.00pt;height:14.00pt;text-align:left;">2000</div><div class="fu-el fu-band-detail" style="left:140.00pt;top:60.00pt;width:200.00pt;height:14.00pt;text-align:left;">2026-08-22 15:00</div><div class="fu-el fu-band-detail" style="left:340.00pt;top:60.00pt;width:160.00pt;height:14.00pt;text-align:right;">$5.00</div><div class="fu-band-overlay fu-band-overlay-col-header" style="top:44.00pt;height:16.00pt;"></div></div></body>
+<div class="rw-page" style="width:612.00pt;height:792.00pt;" data-page="1"><div class="rw-el rw-band-title" style="left:20.00pt;top:20.00pt;width:572.00pt;height:24.00pt;text-align:center;">Open Tabs</div><div class="rw-el rw-band-col-header" style="left:20.00pt;top:44.00pt;width:120.00pt;height:16.00pt;text-align:left;">Order</div><div class="rw-el rw-band-col-header" style="left:140.00pt;top:44.00pt;width:200.00pt;height:16.00pt;text-align:left;">Opened</div><div class="rw-el rw-band-col-header" style="left:340.00pt;top:44.00pt;width:160.00pt;height:16.00pt;text-align:right;">Running Total</div><div class="rw-el rw-band-detail" style="left:20.00pt;top:60.00pt;width:120.00pt;height:14.00pt;text-align:left;">2000</div><div class="rw-el rw-band-detail" style="left:140.00pt;top:60.00pt;width:200.00pt;height:14.00pt;text-align:left;">2026-08-22 15:00</div><div class="rw-el rw-band-detail" style="left:340.00pt;top:60.00pt;width:160.00pt;height:14.00pt;text-align:right;">$5.00</div><div class="rw-band-overlay rw-band-overlay-col-header" style="top:44.00pt;height:16.00pt;"></div></div></body>
 </html>

--- a/writer-app/tests/Snapshots/sales-by-category.html
+++ b/writer-app/tests/Snapshots/sales-by-category.html
@@ -5,18 +5,18 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <style>
 body{margin:0;padding:20pt;background:#e0e0e0;font-family:sans-serif}
-.fu-page{position:relative;background:#fff;margin:0 auto 24pt;box-shadow:0 2px 8px rgba(0,0,0,.25);overflow:hidden}
-.fu-el{position:absolute;box-sizing:border-box;font-size:9pt;line-height:1.3;overflow:hidden;white-space:pre-wrap}
-.fu-band-overlay{position:absolute;left:0;width:100%;pointer-events:none;}
-.fu-band-title{font-size:14pt;font-weight:bold;text-align:center;color:#1a1a2e;}.fu-band-col-header{font-weight:bold;}.fu-band-group-header{font-weight:bold;color:#1a1a2e;}.fu-band-group-footer{font-style:italic;color:#555555;}.fu-band-summary{color:#555555;font-style:italic;}.fu-band-overlay-col-header{border-bottom:1px solid #333;}
+.rw-page{position:relative;background:#fff;margin:0 auto 24pt;box-shadow:0 2px 8px rgba(0,0,0,.25);overflow:hidden}
+.rw-el{position:absolute;box-sizing:border-box;font-size:9pt;line-height:1.3;overflow:hidden;white-space:pre-wrap}
+.rw-band-overlay{position:absolute;left:0;width:100%;pointer-events:none;}
+.rw-band-title{font-size:14pt;font-weight:bold;text-align:center;color:#1a1a2e;}.rw-band-col-header{font-weight:bold;}.rw-band-group-header{font-weight:bold;color:#1a1a2e;}.rw-band-group-footer{font-style:italic;color:#555555;}.rw-band-summary{color:#555555;font-style:italic;}.rw-band-overlay-col-header{border-bottom:1px solid #333;}
 @media print{
 @page{margin:0}
 body{padding:0;background:none}
-.fu-page{margin:0;box-shadow:none;break-after:page;page-break-after:always}
-.fu-page:last-child{break-after:avoid;page-break-after:avoid}
+.rw-page{margin:0;box-shadow:none;break-after:page;page-break-after:always}
+.rw-page:last-child{break-after:avoid;page-break-after:avoid}
 }
 </style>
 </head>
 <body>
-<div class="fu-page" style="width:612.00pt;height:792.00pt;" data-page="1"><div class="fu-el fu-band-title" style="left:20.00pt;top:20.00pt;width:572.00pt;height:24.00pt;text-align:center;">Sales by Category — 2026-08-22</div><div class="fu-el fu-band-col-header" style="left:20.00pt;top:44.00pt;width:300.00pt;height:16.00pt;text-align:left;">Category</div><div class="fu-el fu-band-col-header" style="left:320.00pt;top:44.00pt;width:180.00pt;height:16.00pt;text-align:right;">Total</div><div class="fu-el fu-band-detail" style="left:20.00pt;top:60.00pt;width:300.00pt;height:14.00pt;text-align:left;">Coffee</div><div class="fu-el fu-band-detail" style="left:320.00pt;top:60.00pt;width:180.00pt;height:14.00pt;text-align:right;">$22.00</div><div class="fu-el fu-band-detail" style="left:20.00pt;top:74.00pt;width:300.00pt;height:14.00pt;text-align:left;">Pastry</div><div class="fu-el fu-band-detail" style="left:320.00pt;top:74.00pt;width:180.00pt;height:14.00pt;text-align:right;">$7.50</div><div class="fu-el fu-band-summary" style="left:20.00pt;top:88.00pt;width:300.00pt;height:16.00pt;text-align:right;">Grand Total</div><div class="fu-el fu-band-summary" style="left:320.00pt;top:88.00pt;width:180.00pt;height:16.00pt;text-align:right;">$29.50</div><div class="fu-band-overlay fu-band-overlay-col-header" style="top:44.00pt;height:16.00pt;"></div></div></body>
+<div class="rw-page" style="width:612.00pt;height:792.00pt;" data-page="1"><div class="rw-el rw-band-title" style="left:20.00pt;top:20.00pt;width:572.00pt;height:24.00pt;text-align:center;">Sales by Category — 2026-08-22</div><div class="rw-el rw-band-col-header" style="left:20.00pt;top:44.00pt;width:300.00pt;height:16.00pt;text-align:left;">Category</div><div class="rw-el rw-band-col-header" style="left:320.00pt;top:44.00pt;width:180.00pt;height:16.00pt;text-align:right;">Total</div><div class="rw-el rw-band-detail" style="left:20.00pt;top:60.00pt;width:300.00pt;height:14.00pt;text-align:left;">Coffee</div><div class="rw-el rw-band-detail" style="left:320.00pt;top:60.00pt;width:180.00pt;height:14.00pt;text-align:right;">$22.00</div><div class="rw-el rw-band-detail" style="left:20.00pt;top:74.00pt;width:300.00pt;height:14.00pt;text-align:left;">Pastry</div><div class="rw-el rw-band-detail" style="left:320.00pt;top:74.00pt;width:180.00pt;height:14.00pt;text-align:right;">$7.50</div><div class="rw-el rw-band-summary" style="left:20.00pt;top:88.00pt;width:300.00pt;height:16.00pt;text-align:right;">Grand Total</div><div class="rw-el rw-band-summary" style="left:320.00pt;top:88.00pt;width:180.00pt;height:16.00pt;text-align:right;">$29.50</div><div class="rw-band-overlay rw-band-overlay-col-header" style="top:44.00pt;height:16.00pt;"></div></div></body>
 </html>

--- a/writer/src/Renderer/HtmlRenderer.php
+++ b/writer/src/Renderer/HtmlRenderer.php
@@ -45,7 +45,7 @@ class HtmlRenderer implements RendererInterface
         $h = $this->pageConfig->getHeight();
 
         $out = sprintf(
-            '<div class="fu-page" style="width:%.2fpt;height:%.2fpt;" data-page="%d">',
+            '<div class="rw-page" style="width:%.2fpt;height:%.2fpt;" data-page="%d">',
             $w,
             $h,
             $page->getPageNumber()
@@ -106,7 +106,7 @@ class HtmlRenderer implements RendererInterface
         }
 
         $style = sprintf('top:%.2fpt;height:%.2fpt;', $minY, $maxH);
-        $class = 'fu-band-overlay fu-band-overlay-' . StyleMap::sanitize($bandType);
+        $class = 'rw-band-overlay rw-band-overlay-' . StyleMap::sanitize($bandType);
 
         return sprintf('<div class="%s" style="%s"></div>', $class, $style);
     }
@@ -131,9 +131,9 @@ class HtmlRenderer implements RendererInterface
             $style .= 'text-align:' . htmlspecialchars($el->getTextAlign(), ENT_QUOTES, 'UTF-8') . ';';
         }
 
-        $class = 'fu-el';
+        $class = 'rw-el';
         if ($el->getBandType() !== '') {
-            $class .= ' fu-band-' . StyleMap::sanitize($el->getBandType());
+            $class .= ' rw-band-' . StyleMap::sanitize($el->getBandType());
         }
 
         return sprintf(
@@ -153,15 +153,15 @@ class HtmlRenderer implements RendererInterface
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <style>
 body{margin:0;padding:20pt;background:#e0e0e0;font-family:sans-serif}
-.fu-page{position:relative;background:#fff;margin:0 auto 24pt;box-shadow:0 2px 8px rgba(0,0,0,.25);overflow:hidden}
-.fu-el{position:absolute;box-sizing:border-box;font-size:9pt;line-height:1.3;overflow:hidden;white-space:pre-wrap}
-.fu-band-overlay{position:absolute;left:0;width:100%;pointer-events:none;}
+.rw-page{position:relative;background:#fff;margin:0 auto 24pt;box-shadow:0 2px 8px rgba(0,0,0,.25);overflow:hidden}
+.rw-el{position:absolute;box-sizing:border-box;font-size:9pt;line-height:1.3;overflow:hidden;white-space:pre-wrap}
+.rw-band-overlay{position:absolute;left:0;width:100%;pointer-events:none;}
 ' . $this->styleMap->toCss() . '
 @media print{
 @page{margin:0}
 body{padding:0;background:none}
-.fu-page{margin:0;box-shadow:none;break-after:page;page-break-after:always}
-.fu-page:last-child{break-after:avoid;page-break-after:avoid}
+.rw-page{margin:0;box-shadow:none;break-after:page;page-break-after:always}
+.rw-page:last-child{break-after:avoid;page-break-after:avoid}
 }
 </style>
 </head>

--- a/writer/src/Renderer/StyleMap.php
+++ b/writer/src/Renderer/StyleMap.php
@@ -21,7 +21,7 @@ class StyleMap
     private array $bandMap;
 
     /**
-     * @param array<string, array<string, string>> $elementMap  Per-element CSS applied to each fu-el div.
+     * @param array<string, array<string, string>> $elementMap  Per-element CSS applied to each rw-el div.
      * @param array<string, array<string, string>> $bandMap     Per-band CSS applied to a full-width overlay div.
      */
     public function __construct(array $elementMap = [], array $bandMap = [])
@@ -94,14 +94,14 @@ class StyleMap
     {
         $css = '';
         foreach ($this->elementMap as $bandType => $styles) {
-            $css .= '.fu-band-' . self::sanitize($bandType) . '{';
+            $css .= '.rw-band-' . self::sanitize($bandType) . '{';
             foreach ($styles as $prop => $value) {
                 $css .= $prop . ':' . $value . ';';
             }
             $css .= '}';
         }
         foreach ($this->bandMap as $bandType => $styles) {
-            $css .= '.fu-band-overlay-' . self::sanitize($bandType) . '{';
+            $css .= '.rw-band-overlay-' . self::sanitize($bandType) . '{';
             foreach ($styles as $prop => $value) {
                 $css .= $prop . ':' . $value . ';';
             }

--- a/writer/tests/Unit/Renderer/HtmlRendererTest.php
+++ b/writer/tests/Unit/Renderer/HtmlRendererTest.php
@@ -76,7 +76,7 @@ class HtmlRendererTest extends TestCase
         $stream = $pipeline->run($filler);
         $html   = (new HtmlRenderer($config))->render($stream);
 
-        $this->assertSame(2, substr_count($html, 'class="fu-page"'));
+        $this->assertSame(2, substr_count($html, 'class="rw-page"'));
         $this->assertStringContainsString('data-page="1"', $html);
         $this->assertStringContainsString('data-page="2"', $html);
         $this->assertStringContainsString('Page one', $html);
@@ -156,7 +156,7 @@ class HtmlRendererTest extends TestCase
         $html   = (new HtmlRenderer($config, \ReportWriter\Renderer\StyleMap::defaults()))->render($stream);
 
         // The overlay div spans full width despite the gap between elements
-        $this->assertStringContainsString('fu-band-overlay', $html);
+        $this->assertStringContainsString('rw-band-overlay', $html);
         $this->assertStringContainsString('border-bottom', $html);
         $this->assertStringContainsString('width:100%', $html);
     }


### PR DESCRIPTION
## Summary
- Renames all `fu-*` CSS class names emitted by `HtmlRenderer` and referenced in `StyleMap`, the Vue viewer, tests, and docs to `rw-*`.
- Rationale (per Lee's directive): the `fu-` prefix was legacy/opaque; `rw-` matches the PHP namespace (`ReportWriter\`) and the published Composer package name (`edgecase123/report-writer`).
- Pre-1.0, no compatibility shim, no ADR (per team decision — cheap CHANGELOG note is enough).

## Files touched
- **Library source:** `writer/src/Renderer/HtmlRenderer.php`, `writer/src/Renderer/StyleMap.php`
- **Library test:** `writer/tests/Unit/Renderer/HtmlRendererTest.php`
- **Viewer:** `frontend/src/components/ReportCanvas.vue` (`.fu-page` / `.fu-el` selectors + comments)
- **Snapshots (regenerated via `UPDATE_SNAPSHOTS=1`):** `writer-app/tests/Snapshots/sales-by-category.html`, `open-tabs.html`
- **Docs:** `docs/tickets/017-title-alignment-vs-columns-vs-page.md`, `docs/03-concepts/what-is-a-report.md`, `docs/superpowers/specs/2026-08-23-title-alignment-design.md`
- **New:** `CHANGELOG.md` (project didn't have one before; created with a Keep-a-Changelog-style entry)

## Class name map
| Before                        | After                        |
|-------------------------------|------------------------------|
| `fu-page`                     | `rw-page`                    |
| `fu-el`                       | `rw-el`                      |
| `fu-band-overlay`             | `rw-band-overlay`            |
| `fu-band-overlay-<bandtype>`  | `rw-band-overlay-<bandtype>` |
| `fu-band-<bandtype>`          | `rw-band-<bandtype>`         |

Pure rename — no structural changes. Diff is 37 insertions / 37 deletions (plus CHANGELOG additions).

## Test plan
- [x] `cd writer && vendor/bin/phpunit` → `OK (163 tests, 300 assertions)` — unchanged
- [x] `cd writer-app && vendor/bin/phpunit` → `OK (70 tests, 136 assertions)` — passes after snapshot regen
- [x] `cd frontend && npm run typecheck` → clean
- [x] Snapshot files contain 7 `rw-*` refs each (same count as the 7 `fu-*` refs they replaced)

## Breaking change note
Any downstream consumer app targeting `.fu-*` selectors in their own CSS must update to `.rw-*`. This is documented in `CHANGELOG.md` (Unreleased section).