### PR TITLE
refactor(reports): extract DateParam::require() (dry-solid Rule 3)

### DIFF
--- a/writer-app/src/Reports/DataSource/DateParam.php
+++ b/writer-app/src/Reports/DataSource/DateParam.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Reports\DataSource;
+
+use InvalidArgumentException;
+
+final class DateParam
+{
+    /** @param array<string, mixed> $params */
+    public static function require(array $params, string $name = 'date'): string
+    {
+        $value = $params[$name] ?? null;
+        if (!is_string($value) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) !== 1) {
+            throw new InvalidArgumentException(sprintf("Parameter '%s' must be YYYY-MM-DD.", $name));
+        }
+        return $value;
+    }
+}

--- a/writer-app/src/Reports/DataSource/SqliteDailySalesProvider.php
+++ b/writer-app/src/Reports/DataSource/SqliteDailySalesProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ReportWriter\App\Reports\DataSource;
 
-use InvalidArgumentException;
 use PDO;
 use ReportWriter\Interfaces\ReportDataSourceInterface;
 
@@ -23,10 +22,7 @@ final class SqliteDailySalesProvider implements ReportDataSourceInterface
      */
     public function fetchRows(array $params): array
     {
-        $date = $params['date'] ?? null;
-        if (!is_string($date) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
-            throw new InvalidArgumentException("Parameter 'date' must be YYYY-MM-DD; got " . var_export($date, true));
-        }
+        $date = DateParam::require($params);
 
         $sql = <<<SQL
             SELECT

--- a/writer-app/src/Reports/DataSource/SqliteSalesByCategoryItemProvider.php
+++ b/writer-app/src/Reports/DataSource/SqliteSalesByCategoryItemProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ReportWriter\App\Reports\DataSource;
 
-use InvalidArgumentException;
 use PDO;
 use ReportWriter\Interfaces\ReportDataSourceInterface;
 
@@ -23,10 +22,7 @@ final class SqliteSalesByCategoryItemProvider implements ReportDataSourceInterfa
      */
     public function fetchRows(array $params): array
     {
-        $date = $params['date'] ?? null;
-        if (!is_string($date) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
-            throw new InvalidArgumentException("Parameter 'date' must be YYYY-MM-DD; got " . var_export($date, true));
-        }
+        $date = DateParam::require($params);
 
         $sql = <<<SQL
             SELECT

--- a/writer-app/src/Reports/DataSource/SqliteSalesByCategoryProvider.php
+++ b/writer-app/src/Reports/DataSource/SqliteSalesByCategoryProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ReportWriter\App\Reports\DataSource;
 
-use InvalidArgumentException;
 use PDO;
 use ReportWriter\Interfaces\ReportDataSourceInterface;
 
@@ -23,10 +22,7 @@ final class SqliteSalesByCategoryProvider implements ReportDataSourceInterface
      */
     public function fetchRows(array $params): array
     {
-        $date = $params['date'] ?? null;
-        if (!is_string($date) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
-            throw new InvalidArgumentException("Parameter 'date' must be YYYY-MM-DD; got " . var_export($date, true));
-        }
+        $date = DateParam::require($params);
 
         $sql = <<<SQL
             SELECT

--- a/writer-app/tests/Unit/Reports/DataSource/DateParamTest.php
+++ b/writer-app/tests/Unit/Reports/DataSource/DateParamTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReportWriter\App\Tests\Unit\Reports\DataSource;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ReportWriter\App\Reports\DataSource\DateParam;
+
+final class DateParamTest extends TestCase
+{
+    public function testReturnsTheDateStringWhenWellFormed(): void
+    {
+        $this->assertSame('2026-08-22', DateParam::require(['date' => '2026-08-22']));
+    }
+
+    public function testUsesCustomParamNameWhenProvided(): void
+    {
+        $this->assertSame('2026-08-22', DateParam::require(['from' => '2026-08-22'], 'from'));
+    }
+
+    public function testThrowsWhenParamMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Parameter 'date' must be YYYY-MM-DD.");
+        DateParam::require([]);
+    }
+
+    public function testThrowsWhenParamNotAString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DateParam::require(['date' => 20260822]);
+    }
+
+    public function testThrowsWhenParamMalformed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DateParam::require(['date' => 'yesterday']);
+    }
+
+    public function testThrowsWithCustomNameInMessage(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Parameter 'from' must be YYYY-MM-DD.");
+        DateParam::require([], 'from');
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts the 4-line YYYY-MM-DD validation duplicated verbatim across all three SQLite providers into `writer-app/src/Reports/DataSource/DateParam::require($params, $name = 'date'): string`.
- Triggered by `dry-solid-reviewer` sub-agent findings against PR #27 (A3.4). Third copy = stop-the-line DRY threshold (Rule 3).
- Simultaneously resolves `security-scanner` advisory on PR #27: the exception message no longer echoes `var_export($date)` (reflected user-input risk if downstream ever surfaces exception messages verbatim). New message is a fixed string.

## Test plan
- [x] `cd writer && vendor/bin/phpunit` → `OK (163 tests, 300 assertions)` — unchanged
- [x] `cd writer-app && vendor/bin/phpunit` → `OK (91 tests, 176 assertions)` (85 A3.4 baseline + 6 new `DateParamTest`)
- [x] All existing provider tests (`SqliteDailySalesProviderTest`, `SqliteSalesByCategoryProviderTest`, `SqliteSalesByCategoryItemProviderTest`) still assert `InvalidArgumentException` on malformed/missing date — behavior unchanged, only message text changed.
- [x] `DateParamTest` covers: well-formed pass-through, custom param name, missing key, non-string value, malformed string, custom name in message.

## Diff shape
- `writer-app/src/Reports/DataSource/DateParam.php` (new, ~15 lines)
- `writer-app/tests/Unit/Reports/DataSource/DateParamTest.php` (new, ~50 lines / 6 tests)
- Each of the 3 SQLite providers: 4 lines of validation + `use InvalidArgumentException` → 1 line `DateParam::require($params)`.